### PR TITLE
Fix govpp libmemif adapter + add gopacket adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 extras:
 	@cd extras/libmemif/examples/raw-data && go build -v
 	@cd extras/libmemif/examples/icmp-responder && go build -v
+	@cd extras/libmemif/examples/gopacket && go build -v
 
 clean:
 	@rm -f cmd/binapi-generator/binapi-generator

--- a/extras/libmemif/README.md
+++ b/extras/libmemif/README.md
@@ -144,9 +144,10 @@ used to decode and construct packets.
 
 The appropriate VPP configuration for the opposite memif is:
 ```
-vpp$ create memif id 1 socket /tmp/icmp-responder-example slave secret secret
-vpp$ set int state memif0/1 up
-vpp$ set int ip address memif0/1 192.168.1.2/24
+vpp$ create memif socket id 1 filename /tmp/icmp-responder-example
+vpp$ create interface memif id 1 socket-id 1 slave secret secret no-zero-copy
+vpp$ set int state memif1/1 up
+vpp$ set int ip address memif1/1 192.168.1.2/24
 ```
 
 To start the example, simply type:

--- a/extras/libmemif/adapter.go
+++ b/extras/libmemif/adapter.go
@@ -55,11 +55,10 @@ typedef struct
 	uint8_t num_s2m_rings;
 	uint8_t num_m2s_rings;
 	uint16_t buffer_size;
-	memif_log2_ring_size_t log2_ring_size;
+	uint8_t log2_ring_size;
 	uint8_t is_master;
-	memif_interface_id_t interface_id;
+	uint32_t interface_id;
 	char *interface_name;
-	char *instance_name;
 	memif_interface_mode_t mode;
 } govpp_memif_conn_args_t;
 
@@ -123,11 +122,6 @@ govpp_memif_create (memif_conn_handle_t *conn, govpp_memif_conn_args_t *go_args,
 	{
 		strncpy ((char *)args.interface_name, go_args->interface_name,
 				 sizeof(args.interface_name) - 1);
-	}
-	if (go_args->instance_name != NULL)
-	{
-		strncpy ((char *)args.instance_name, go_args->instance_name,
-				 sizeof (args.instance_name) - 1);
 	}
 	args.mode = go_args->mode;
 
@@ -204,8 +198,8 @@ govpp_get_tx_queue_details (govpp_memif_details_t *md, int index)
 static void
 govpp_copy_packet_data(memif_buffer_t *buffers, int index, void *data, uint32_t size)
 {
-	buffers[index].data_len = (size > buffers[index].buffer_len ? buffers[index].buffer_len : size);
-	memcpy(buffers[index].data, data, (size_t)buffers[index].data_len);
+	buffers[index].len = (size > buffers[index].len ? buffers[index].len : size);
+	memcpy(buffers[index].data, data, (size_t)buffers[index].len);
 }
 
 // Get packet data from the selected buffer.
@@ -213,7 +207,7 @@ govpp_copy_packet_data(memif_buffer_t *buffers, int index, void *data, uint32_t 
 static void *
 govpp_get_packet_data(memif_buffer_t *buffers, int index, int *size)
 {
-	*size = (int)buffers[index].data_len;
+	*size = (int)buffers[index].len;
 	return buffers[index].data;
 }
 
@@ -350,6 +344,7 @@ type Memif struct {
 	queueIntCh []chan struct{} // per RX queue interrupt channel
 
 	// Rx/Tx queues
+	ringSize    int              // number of items in each ring
 	stopQPollFd int              // event file descriptor used to stop pollRxQueue-s
 	wg          sync.WaitGroup   // wait group for all pollRxQueue-s
 	rxQueueBufs []CPacketBuffers // an array of C-libmemif packet buffers for each RX queue
@@ -444,11 +439,11 @@ func Init(appName string) error {
 	// Initialize C-libmemif.
 	var errCode int
 	if appName == "" {
-		errCode = int(C.memif_init(nil, nil))
+		errCode = int(C.memif_init(nil, nil, nil, nil))
 	} else {
 		appName := C.CString(appName)
 		defer C.free(unsafe.Pointer(appName))
-		errCode = int(C.memif_init(nil, appName))
+		errCode = int(C.memif_init(nil, appName, nil, nil))
 	}
 	err := getMemifError(errCode)
 	if err != nil {
@@ -517,11 +512,17 @@ func CreateInterface(config *MemifConfig, callbacks *MemifCallbacks) (memif *Mem
 
 	log.WithField("ifName", config.IfName).Debug("Creating a new memif interface")
 
+	log2RingSize := config.Log2RingSize
+	if log2RingSize == 0 {
+		log2RingSize = 10
+	}
+
 	// Create memif-wrapper for Go-libmemif.
 	memif = &Memif{
 		MemifMeta: config.MemifMeta,
 		callbacks: &MemifCallbacks{},
 		ifIndex:   context.nextMemifIndex,
+		ringSize:  1 << log2RingSize,
 	}
 
 	// Initialize memif callbacks.
@@ -547,16 +548,11 @@ func CreateInterface(config *MemifConfig, callbacks *MemifCallbacks) (memif *Mem
 		defer C.free(unsafe.Pointer(args.socket_filename))
 	}
 	// - interface ID
-	args.interface_id = C.memif_interface_id_t(config.ConnID)
+	args.interface_id = C.uint32_t(config.ConnID)
 	// - interface name
 	if config.IfName != "" {
 		args.interface_name = C.CString(config.IfName)
 		defer C.free(unsafe.Pointer(args.interface_name))
-	}
-	// - instance name
-	if config.InstanceName != "" {
-		args.instance_name = C.CString(config.InstanceName)
-		defer C.free(unsafe.Pointer(args.instance_name))
 	}
 	// - mode
 	switch config.Mode {
@@ -587,7 +583,7 @@ func CreateInterface(config *MemifConfig, callbacks *MemifCallbacks) (memif *Mem
 	// - buffer size
 	args.buffer_size = C.uint16_t(config.BufferSize)
 	// - log_2(ring size)
-	args.log2_ring_size = C.memif_log2_ring_size_t(config.Log2RingSize)
+	args.log2_ring_size = C.uint8_t(config.Log2RingSize)
 
 	// Create memif in C-libmemif.
 	errCode := C.govpp_memif_create(&memif.cHandle, args, unsafe.Pointer(uintptr(memif.ifIndex)))
@@ -757,7 +753,7 @@ func (memif *Memif) TxBurst(queueID uint8, packets []RawPacketData) (count uint1
 	// Allocate ring slots.
 	cQueueID := C.uint16_t(queueID)
 	errCode := C.memif_buffer_alloc(memif.cHandle, cQueueID, pb.buffers, C.uint16_t(bufCount),
-		&allocated, C.uint16_t(bufSize))
+		&allocated, C.uint32_t(bufSize))
 	err = getMemifError(int(errCode))
 	if err == ErrNoBufRing {
 		// Not enough ring slots, <count> will be less than bufCount.
@@ -793,7 +789,6 @@ func (memif *Memif) TxBurst(queueID uint8, packets []RawPacketData) (count uint1
 // Rx queue.
 func (memif *Memif) RxBurst(queueID uint8, count uint16) (packets []RawPacketData, err error) {
 	var recvCount C.uint16_t
-	var freed C.uint16_t
 
 	if count == 0 {
 		return packets, nil
@@ -836,7 +831,9 @@ func (memif *Memif) RxBurst(queueID uint8, count uint16) (packets []RawPacketDat
 		packets = append(packets, C.GoBytes(packetData, packetSize))
 	}
 
-	errCode = C.memif_buffer_free(memif.cHandle, cQueueID, pb.buffers, recvCount, &freed)
+	if recvCount > 0 {
+		errCode = C.memif_refill_queue(memif.cHandle, cQueueID, recvCount, 0)
+	}
 	err = getMemifError(int(errCode))
 	if err != nil {
 		// Throw away packets to avoid duplicities.
@@ -895,6 +892,13 @@ func (memif *Memif) initQueues() error {
 	// Initialize Rx/Tx packet buffers.
 	for i = 0; i < len(details.RxQueues); i++ {
 		memif.rxQueueBufs = append(memif.rxQueueBufs, CPacketBuffers{})
+		if !memif.IsMaster {
+			errCode := C.memif_refill_queue(memif.cHandle, C.uint16_t(i), C.uint16_t(memif.ringSize-1), 0)
+			err = getMemifError(int(errCode))
+			if err != nil {
+				log.Warn(err.Error())
+			}
+		}
 	}
 	for i = 0; i < len(details.TxQueues); i++ {
 		memif.txQueueBufs = append(memif.txQueueBufs, CPacketBuffers{})

--- a/extras/libmemif/examples/gopacket/gopacket.go
+++ b/extras/libmemif/examples/gopacket/gopacket.go
@@ -1,0 +1,166 @@
+// gopacket is simple example how to use alternative method of using gopacket calls and packet handles
+// to implement simple use-case that is shown in raw-data. For more informations check raw-data example.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+
+	"git.fd.io/govpp.git/extras/libmemif"
+	"io"
+)
+
+const (
+	Socket             = "/tmp/gopacket-example"
+	Secret             = "secret"
+	ConnectionID       = 1
+	NumQueues    uint8 = 3
+)
+
+var stopCh chan struct{}
+
+func OnConnect(memif *libmemif.Memif) (err error) {
+	details, err := memif.GetDetails()
+
+	if err != nil {
+		fmt.Printf("libmemif.GetDetails() error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("memif %s has been connected: %+v\n", memif.IfName, details)
+
+	stopCh = make(chan struct{})
+
+	for _, queue := range details.RxQueues {
+		ch, err := memif.GetQueueInterruptChan(queue.QueueID)
+		if err != nil {
+			continue
+		}
+
+		go ReadPackets(memif.NewPacketHandle(queue.QueueID, 3), ch)
+	}
+
+	for _, queue := range details.TxQueues {
+		go SendPackets(memif.NewPacketHandle(queue.QueueID, 3))
+	}
+
+	return nil
+}
+
+func OnDisconnect(memif *libmemif.Memif) (err error) {
+	fmt.Printf("memif %s has been disconnected\n", memif.IfName)
+	close(stopCh)
+	return nil
+}
+
+func ReadPackets(handle libmemif.MemifPacketHandle, interruptCh <-chan struct{}) {
+	for {
+		select {
+		case <-interruptCh:
+		read:
+			for {
+				data, _, err := handle.ReadPacketData()
+
+				switch err {
+				case io.EOF:
+					break read
+				case nil:
+					fmt.Printf("Received packet %v\n", string(data[:]))
+				default:
+					fmt.Printf("Got error while reading packet %v\n", err)
+				}
+			}
+		case <-stopCh:
+			handle.Close()
+			return
+		}
+	}
+}
+
+func SendPackets(handle libmemif.MemifPacketHandle) {
+	counter := 0
+
+	for {
+		select {
+		case <-time.After(3 * time.Second):
+			counter++
+
+			// Prepare fake packets.
+			packets := [][]byte{
+				[]byte("Packet #1 in burst number " + strconv.Itoa(counter)),
+				[]byte("Packet #2 in burst number " + strconv.Itoa(counter)),
+				[]byte("Packet #3 in burst number " + strconv.Itoa(counter)),
+			}
+
+		write:
+			for _, data := range packets {
+				err := handle.WritePacketData(data)
+
+				switch err {
+				case io.EOF:
+					break write
+				case nil:
+					fmt.Printf("Sent packet %v\n", string(data[:]))
+				default:
+					fmt.Printf("Got error while sending packet %v\n", err)
+				}
+			}
+		case <-stopCh:
+			handle.Close()
+			return
+		}
+	}
+}
+
+func main() {
+	var isMaster = true
+	var appSuffix string
+	if len(os.Args) > 1 && (os.Args[1] == "--slave" || os.Args[1] == "-slave") {
+		isMaster = false
+		appSuffix = "-slave"
+	}
+
+	appName := "gopacket" + appSuffix
+	err := libmemif.Init(appName)
+	if err != nil {
+		fmt.Printf("libmemif.Init() error: %v\n", err)
+		return
+	}
+
+	defer libmemif.Cleanup()
+
+	memifCallbacks := &libmemif.MemifCallbacks{
+		OnConnect:    OnConnect,
+		OnDisconnect: OnDisconnect,
+	}
+
+	memifConfig := &libmemif.MemifConfig{
+		MemifMeta: libmemif.MemifMeta{
+			IfName:         "memif1",
+			ConnID:         ConnectionID,
+			SocketFilename: Socket,
+			Secret:         Secret,
+			IsMaster:       isMaster,
+			Mode:           libmemif.IfModeEthernet,
+		},
+		MemifShmSpecs: libmemif.MemifShmSpecs{
+			NumRxQueues: NumQueues,
+			NumTxQueues: NumQueues,
+		},
+	}
+
+	memif, err := libmemif.CreateInterface(memifConfig, memifCallbacks)
+	if err != nil {
+		fmt.Printf("libmemif.CreateInterface() error: %v\n", err)
+		return
+	}
+
+	defer memif.Close()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	<-sigChan
+}

--- a/extras/libmemif/examples/icmp-responder/icmp-responder.go
+++ b/extras/libmemif/examples/icmp-responder/icmp-responder.go
@@ -3,9 +3,10 @@
 // and construct packets.
 //
 // The appropriate VPP configuration for the opposite memif is:
-//   vpp$ create memif id 1 socket /tmp/icmp-responder-example slave secret secret
-//   vpp$ set int state memif0/1 up
-//   vpp$ set int ip address memif0/1 192.168.1.2/24
+//   vpp$ create memif socket id 1 filename /tmp/icmp-responder-example
+//   vpp$ create interface memif id 1 socket-id 1 slave secret secret no-zero-copy
+//   vpp$ set int state memif1/1 up
+//   vpp$ set int ip address memif1/1 192.168.1.2/24
 //
 // To start the example, simply type:
 //   root$ ./icmp-responder

--- a/extras/libmemif/packethandle.go
+++ b/extras/libmemif/packethandle.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libmemif
+
+import (
+	"github.com/google/gopacket"
+	"time"
+	"sync"
+	"io"
+)
+
+type memoizedPacket struct {
+	data RawPacketData
+	co   gopacket.CaptureInfo
+}
+
+type MemifPacketHandle struct {
+	memif   *Memif
+	queueId uint8
+	rxCount uint16
+
+	// Used for caching packets when larger rxburst is called
+	packetQueue []*memoizedPacket
+
+	// Used for synchronization of read/write calls
+	readMu  sync.Mutex
+	writeMu sync.Mutex
+	closeMu sync.Mutex
+	stop    bool
+}
+
+// Create new GoPacket packet handle from libmemif queue. rxCount determines how many packets will be read
+// at once, minimum value is 1
+func (memif *Memif) NewPacketHandle(queueId uint8, rxCount uint16) MemifPacketHandle {
+	if rxCount == 0 {
+		rxCount = 1
+	}
+
+	return MemifPacketHandle{
+		memif:   memif,
+		queueId: queueId,
+		rxCount: rxCount,
+	}
+}
+
+// Reads packet data from memif in bursts, based on previously configured rxCount parameterer. Then caches the
+// resulting packets and returns them 1 by 1 from this method until queue is empty then tries to call new rx burst
+// to read more data. If no data is returned, io.EOF error is thrown and caller should stop reading.
+func (handle *MemifPacketHandle) ReadPacketData() (data []byte, co gopacket.CaptureInfo, err error) {
+	handle.readMu.Lock()
+	defer handle.readMu.Unlock()
+
+	if handle.stop {
+		err = io.EOF
+		return
+	}
+
+	queueLen := len(handle.packetQueue)
+
+	if queueLen == 0 {
+		packets, burstErr := handle.memif.RxBurst(handle.queueId, handle.rxCount)
+		packetsLen := len(packets)
+
+		if burstErr == nil && packetsLen == 0 {
+			err = io.EOF
+			return
+		}
+
+		handle.packetQueue = make([]*memoizedPacket, packetsLen)
+
+		for i, packet := range packets {
+			packetLen := len(packet)
+
+			handle.packetQueue[i] = &memoizedPacket{
+				data: []byte(packet),
+				co: gopacket.CaptureInfo{
+					Timestamp:     time.Now(),
+					CaptureLength: packetLen,
+					Length:        packetLen,
+				},
+			}
+		}
+	}
+
+	packet := handle.packetQueue[0]
+	handle.packetQueue = handle.packetQueue[1:]
+	data = packet.data
+	co = packet.co
+
+	return
+}
+
+// Writes packet data to memif in burst of 1 packet. In case no packet is sent, this method throws io.EOF error and
+// called should stop trying to write packets.
+func (handle *MemifPacketHandle) WritePacketData(data []byte) (err error) {
+	handle.writeMu.Lock()
+	defer handle.writeMu.Unlock()
+
+	if handle.stop {
+		err = io.EOF
+		return
+	}
+
+	count, err := handle.memif.TxBurst(handle.queueId, []RawPacketData{data})
+
+	if err != nil {
+		return
+	}
+
+	if count == 0 {
+		err = io.EOF
+	}
+
+	return
+}
+
+// Waits for all read and write operations to finish and then prevents more from occurring. Handle can be closed only
+// once and then can never be opened again.
+func (handle *MemifPacketHandle) Close() {
+	handle.closeMu.Lock()
+	defer handle.closeMu.Unlock()
+
+	// wait for packet reader to stop
+	handle.readMu.Lock()
+	defer handle.readMu.Unlock()
+
+	// wait for packet writer to stop
+	handle.writeMu.Lock()
+	defer handle.writeMu.Unlock()
+
+	// stop reading and writing
+	handle.stop = true
+}


### PR DESCRIPTION
- Fix govpp bindings for libmemif (depends on yet uncomitted changes in libmemif, also assumes the memif_buffer_alloc size was changed from uint16 to uint32)
- Add simple gopacket adapter