### PR TITLE
WIP - Add support for jumbo frames to libmemif adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 extras:
 	@cd extras/libmemif/examples/raw-data && go build -v
 	@cd extras/libmemif/examples/icmp-responder && go build -v
+	@cd extras/libmemif/examples/gopacket && go build -v
 
 clean:
 	@rm -f cmd/binapi-generator/binapi-generator

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install:
 
 extras:
 	@cd extras/libmemif/examples/raw-data && go build -v
+	@cd extras/libmemif/examples/jumbo-frames && go build -v
 	@cd extras/libmemif/examples/icmp-responder && go build -v
 	@cd extras/libmemif/examples/gopacket && go build -v
 

--- a/extras/libmemif/README.md
+++ b/extras/libmemif/README.md
@@ -144,9 +144,10 @@ used to decode and construct packets.
 
 The appropriate VPP configuration for the opposite memif is:
 ```
-vpp$ create memif id 1 socket /tmp/icmp-responder-example slave secret secret
-vpp$ set int state memif0/1 up
-vpp$ set int ip address memif0/1 192.168.1.2/24
+vpp$ create memif socket id 1 filename /tmp/icmp-responder-example
+vpp$ create interface memif id 1 socket-id 1 slave secret secret no-zero-copy
+vpp$ set int state memif1/1 up
+vpp$ set int ip address memif1/1 192.168.1.2/24
 ```
 
 To start the example, simply type:

--- a/extras/libmemif/adapter.go
+++ b/extras/libmemif/adapter.go
@@ -205,10 +205,22 @@ govpp_copy_packet_data(memif_buffer_t *buffers, int index, void *data, uint32_t 
 // Get packet data from the selected buffer.
 // Used to avoid an ugly unsafe.Pointer() + unsafe.Sizeof().
 static void *
-govpp_get_packet_data(memif_buffer_t *buffers, int index, int *size)
+govpp_get_packet_data(memif_buffer_t *buffers, int index, uint32_t *size)
 {
 	*size = (int)buffers[index].len;
 	return buffers[index].data;
+}
+
+static int
+govpp_is_buffer_chained(memif_buffer_t *buffers, int index)
+{
+    return buffers[index].flags & MEMIF_BUFFER_FLAG_NEXT;
+}
+
+static memif_buffer_t *
+govpp_move_buffers_by(memif_buffer_t *buffers, int offset)
+{
+    return (buffers + offset);
 }
 
 */
@@ -345,6 +357,7 @@ type Memif struct {
 
 	// Rx/Tx queues
 	ringSize    int              // number of items in each ring
+	bufferSize  int              // max buffer size
 	stopQPollFd int              // event file descriptor used to stop pollRxQueue-s
 	wg          sync.WaitGroup   // wait group for all pollRxQueue-s
 	rxQueueBufs []CPacketBuffers // an array of C-libmemif packet buffers for each RX queue
@@ -388,6 +401,7 @@ type MemifQueueDetails struct {
 type CPacketBuffers struct {
 	buffers *C.memif_buffer_t
 	count   int
+	chained bool
 }
 
 // Context is a global Go-libmemif runtime context.
@@ -398,6 +412,12 @@ type Context struct {
 	nextMemifIndex int
 
 	wg sync.WaitGroup /* wait-group for pollEvents() */
+}
+
+type txPacketBuffer struct {
+	packets []RawPacketData
+	size    int
+	length  int
 }
 
 var (
@@ -517,12 +537,18 @@ func CreateInterface(config *MemifConfig, callbacks *MemifCallbacks) (memif *Mem
 		log2RingSize = 10
 	}
 
+	bufferSize := config.BufferSize
+	if bufferSize == 0 {
+		bufferSize = 2048
+	}
+
 	// Create memif-wrapper for Go-libmemif.
 	memif = &Memif{
-		MemifMeta: config.MemifMeta,
-		callbacks: &MemifCallbacks{},
-		ifIndex:   context.nextMemifIndex,
-		ringSize:  1 << log2RingSize,
+		MemifMeta:  config.MemifMeta,
+		callbacks:  &MemifCallbacks{},
+		ifIndex:    context.nextMemifIndex,
+		ringSize:   1 << log2RingSize,
+		bufferSize: int(bufferSize),
 	}
 
 	// Initialize memif callbacks.
@@ -717,10 +743,6 @@ func (memif *Memif) GetDetails() (details *MemifDetails, err error) {
 // Multiple TxBurst-s can run concurrently provided that each targets a different
 // TX queue.
 func (memif *Memif) TxBurst(queueID uint8, packets []RawPacketData) (count uint16, err error) {
-	var sentCount C.uint16_t
-	var allocated C.uint16_t
-	var bufSize int
-
 	if len(packets) == 0 {
 		return 0, nil
 	}
@@ -729,16 +751,89 @@ func (memif *Memif) TxBurst(queueID uint8, packets []RawPacketData) (count uint1
 		return 0, ErrQueueID
 	}
 
-	// The largest packet in the set determines the packet buffer size.
+	var buffers []*txPacketBuffer
+	var bufCount int
+
+	cQueueID := C.uint16_t(queueID)
+
 	for _, packet := range packets {
-		if len(packet) > int(bufSize) {
-			bufSize = len(packet)
+		packetLen := len(packet)
+		log.Debugf("%v - preparing packet with len %v", cQueueID, packetLen)
+
+		if packetLen > memif.bufferSize {
+			var newPackets []RawPacketData
+
+			// Define current packet start that will be increased until it reaches end of packet
+			packetStart := 0
+
+			// Start splitting until nothing is left
+			for {
+				// Limit packet end to be size of packet or packet start + max len
+				packetEnd := packetStart + memif.bufferSize
+
+				if packetEnd > packetLen {
+					packetEnd = packetLen
+				}
+
+				// If this is not empty part, process it
+				if packetStart != packetEnd {
+					// Prepare data for next packet part
+					packetPart := packet[packetStart:packetEnd]
+
+					// Append packet part to packets
+					newPackets = append(newPackets, packetPart)
+					bufCount += 1
+				}
+
+				// No more data, quit
+				if packetEnd == packetLen {
+					break
+				}
+
+				// Increase packet start to next split
+				packetStart += memif.bufferSize
+			}
+
+			// Create pseudo-buffer
+			buffer := &txPacketBuffer{
+				size:    packetLen,
+				packets: newPackets,
+				length:  1,
+			}
+
+			buffers = append(buffers, buffer)
+		} else {
+			buffersLen := len(buffers)
+
+			// This is very first buffer so there is no data to append to, prepare empty one
+			if buffersLen == 0 {
+				buffers = []*txPacketBuffer{{}}
+				buffersLen = 1
+			}
+
+			lastBuffer := buffers[buffersLen-1]
+
+			// Last buffer is jumbo buffer, create new buffer
+			if lastBuffer.size > memif.bufferSize {
+				lastBuffer = &txPacketBuffer{}
+				buffers = append(buffers, lastBuffer)
+			}
+
+			// Determine buffer size by max packet size in buffer
+			if packetLen > lastBuffer.size {
+				lastBuffer.size = packetLen
+			}
+
+			lastBuffer.packets = append(lastBuffer.packets, packet)
+			lastBuffer.length = len(lastBuffer.packets)
+			bufCount += 1
 		}
 	}
 
+	log.Debugf("%v - total buffer to allocate count %v", cQueueID, bufCount)
+
 	// Reallocate Tx buffers if needed to fit the input packets.
-	pb := memif.txQueueBufs[queueID]
-	bufCount := len(packets)
+	pb := &memif.txQueueBufs[queueID]
 	if pb.count < bufCount {
 		newBuffers := C.realloc(unsafe.Pointer(pb.buffers), C.size_t(bufCount*int(C.sizeof_memif_buffer_t)))
 		if newBuffers == nil {
@@ -751,32 +846,57 @@ func (memif *Memif) TxBurst(queueID uint8, packets []RawPacketData) (count uint1
 	}
 
 	// Allocate ring slots.
-	cQueueID := C.uint16_t(queueID)
-	errCode := C.memif_buffer_alloc(memif.cHandle, cQueueID, pb.buffers, C.uint16_t(bufCount),
-		&allocated, C.uint32_t(bufSize))
-	err = getMemifError(int(errCode))
-	if err == ErrNoBufRing {
-		// Not enough ring slots, <count> will be less than bufCount.
-		err = nil
+	var totalAllocated C.uint16_t
+	var subCount int
+	for _, buffer := range buffers {
+		log.Debugf("%v - trying to send max buff size %v, packets len %v, buffer len %v", cQueueID, buffer.size, len(buffer.packets), buffer.length)
+
+		// Move buffer pointer to start after last allocated buffer
+		fromCurBuffers := C.govpp_move_buffers_by(pb.buffers, C.int(totalAllocated))
+
+		var allocated C.uint16_t
+		errCode := C.memif_buffer_alloc(memif.cHandle, cQueueID, fromCurBuffers, C.uint16_t(buffer.length),
+			&allocated, C.uint32_t(buffer.size))
+
+		err = getMemifError(int(errCode))
+		endNow := false
+		if err == ErrNoBufRing {
+			// Not enough ring slots, <count> will be less than bufCount.
+			endNow = true
+			err = nil
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		totalAllocated += allocated
+
+		// Copy packet data into the buffers.
+		for i := 0; i < int(allocated); i++ {
+			packetData := unsafe.Pointer(&buffer.packets[i][0])
+			C.govpp_copy_packet_data(fromCurBuffers, C.int(i), packetData, C.uint32_t(len(buffer.packets[i])))
+		}
+
+		if buffer.size > memif.bufferSize {
+			if int(allocated) == len(buffer.packets) {
+				subCount += len(buffer.packets) - 1
+			}
+		}
+
+		if endNow {
+			break
+		}
 	}
+
+	var sentCount C.uint16_t
+	errCode := C.memif_tx_burst(memif.cHandle, cQueueID, pb.buffers, totalAllocated, &sentCount)
+	err = getMemifError(int(errCode))
 	if err != nil {
 		return 0, err
 	}
 
-	// Copy packet data into the buffers.
-	for i := 0; i < int(allocated); i++ {
-		packetData := unsafe.Pointer(&packets[i][0])
-		C.govpp_copy_packet_data(pb.buffers, C.int(i), packetData, C.uint32_t(len(packets[i])))
-	}
-
-	errCode = C.memif_tx_burst(memif.cHandle, cQueueID, pb.buffers, allocated, &sentCount)
-	err = getMemifError(int(errCode))
-	if err != nil {
-		return 0, err
-	}
-	count = uint16(sentCount)
-
-	return count, nil
+	log.Debugf("%v - sent %v sub %v total allocated buffs %v", cQueueID, sentCount, subCount, totalAllocated)
+	return uint16(sentCount) - uint16(subCount), nil
 }
 
 // RxBurst is used to receive multiple packets in one call from a selected queue.
@@ -799,7 +919,7 @@ func (memif *Memif) RxBurst(queueID uint8, count uint16) (packets []RawPacketDat
 	}
 
 	// Reallocate Rx buffers if needed to fit the output packets.
-	pb := memif.rxQueueBufs[queueID]
+	pb := &memif.rxQueueBufs[queueID]
 	bufCount := int(count)
 	if pb.count < bufCount {
 		newBuffers := C.realloc(unsafe.Pointer(pb.buffers), C.size_t(bufCount*int(C.sizeof_memif_buffer_t)))
@@ -826,9 +946,24 @@ func (memif *Memif) RxBurst(queueID uint8, count uint16) (packets []RawPacketDat
 
 	// Copy packet data into the instances of RawPacketData.
 	for i := 0; i < int(recvCount); i++ {
-		var packetSize C.int
+		var packetSize C.uint32_t
 		packetData := C.govpp_get_packet_data(pb.buffers, C.int(i), &packetSize)
-		packets = append(packets, C.GoBytes(packetData, packetSize))
+		packetBytes := C.GoBytes(packetData, C.int(packetSize))
+
+		// TODO: Current API do not supports chaining after we run out of buffers and proceed to next burst
+		if pb.chained && len(packets) == 0 {
+			log.Warn("Previous buffer was chained but there was not enough buffers left so packet got split anyway.")
+			pb.chained = false
+		}
+
+		if pb.chained {
+			prevPacket := packets[len(packets)-1]
+			packets[len(packets)-1] = append(prevPacket, packetBytes...)
+		} else {
+			packets = append(packets, packetBytes)
+		}
+
+		pb.chained = C.govpp_is_buffer_chained(pb.buffers, C.int(i)) > 0
 	}
 
 	if recvCount > 0 {

--- a/extras/libmemif/adapter.go
+++ b/extras/libmemif/adapter.go
@@ -55,11 +55,10 @@ typedef struct
 	uint8_t num_s2m_rings;
 	uint8_t num_m2s_rings;
 	uint16_t buffer_size;
-	memif_log2_ring_size_t log2_ring_size;
+	uint8_t log2_ring_size;
 	uint8_t is_master;
-	memif_interface_id_t interface_id;
+	uint32_t interface_id;
 	char *interface_name;
-	char *instance_name;
 	memif_interface_mode_t mode;
 } govpp_memif_conn_args_t;
 
@@ -123,11 +122,6 @@ govpp_memif_create (memif_conn_handle_t *conn, govpp_memif_conn_args_t *go_args,
 	{
 		strncpy ((char *)args.interface_name, go_args->interface_name,
 				 sizeof(args.interface_name) - 1);
-	}
-	if (go_args->instance_name != NULL)
-	{
-		strncpy ((char *)args.instance_name, go_args->instance_name,
-				 sizeof (args.instance_name) - 1);
 	}
 	args.mode = go_args->mode;
 
@@ -204,8 +198,8 @@ govpp_get_tx_queue_details (govpp_memif_details_t *md, int index)
 static void
 govpp_copy_packet_data(memif_buffer_t *buffers, int index, void *data, uint32_t size)
 {
-	buffers[index].data_len = (size > buffers[index].buffer_len ? buffers[index].buffer_len : size);
-	memcpy(buffers[index].data, data, (size_t)buffers[index].data_len);
+	buffers[index].len = (size > buffers[index].len ? buffers[index].len : size);
+	memcpy(buffers[index].data, data, (size_t)buffers[index].len);
 }
 
 // Get packet data from the selected buffer.
@@ -213,7 +207,7 @@ govpp_copy_packet_data(memif_buffer_t *buffers, int index, void *data, uint32_t 
 static void *
 govpp_get_packet_data(memif_buffer_t *buffers, int index, int *size)
 {
-	*size = (int)buffers[index].data_len;
+	*size = (int)buffers[index].len;
 	return buffers[index].data;
 }
 
@@ -350,6 +344,7 @@ type Memif struct {
 	queueIntCh []chan struct{} // per RX queue interrupt channel
 
 	// Rx/Tx queues
+	ringSize    int              // number of items in each ring
 	stopQPollFd int              // event file descriptor used to stop pollRxQueue-s
 	wg          sync.WaitGroup   // wait group for all pollRxQueue-s
 	rxQueueBufs []CPacketBuffers // an array of C-libmemif packet buffers for each RX queue
@@ -444,11 +439,11 @@ func Init(appName string) error {
 	// Initialize C-libmemif.
 	var errCode int
 	if appName == "" {
-		errCode = int(C.memif_init(nil, nil))
+		errCode = int(C.memif_init(nil, nil, nil, nil))
 	} else {
 		appName := C.CString(appName)
 		defer C.free(unsafe.Pointer(appName))
-		errCode = int(C.memif_init(nil, appName))
+		errCode = int(C.memif_init(nil, appName, nil, nil))
 	}
 	err := getMemifError(errCode)
 	if err != nil {
@@ -517,11 +512,17 @@ func CreateInterface(config *MemifConfig, callbacks *MemifCallbacks) (memif *Mem
 
 	log.WithField("ifName", config.IfName).Debug("Creating a new memif interface")
 
+	log2RingSize := config.Log2RingSize
+	if log2RingSize == 0 {
+		log2RingSize = 10
+	}
+
 	// Create memif-wrapper for Go-libmemif.
 	memif = &Memif{
 		MemifMeta: config.MemifMeta,
 		callbacks: &MemifCallbacks{},
 		ifIndex:   context.nextMemifIndex,
+		ringSize:  1 << log2RingSize,
 	}
 
 	// Initialize memif callbacks.
@@ -547,16 +548,11 @@ func CreateInterface(config *MemifConfig, callbacks *MemifCallbacks) (memif *Mem
 		defer C.free(unsafe.Pointer(args.socket_filename))
 	}
 	// - interface ID
-	args.interface_id = C.memif_interface_id_t(config.ConnID)
+	args.interface_id = C.uint32_t(config.ConnID)
 	// - interface name
 	if config.IfName != "" {
 		args.interface_name = C.CString(config.IfName)
 		defer C.free(unsafe.Pointer(args.interface_name))
-	}
-	// - instance name
-	if config.InstanceName != "" {
-		args.instance_name = C.CString(config.InstanceName)
-		defer C.free(unsafe.Pointer(args.instance_name))
 	}
 	// - mode
 	switch config.Mode {
@@ -587,7 +583,7 @@ func CreateInterface(config *MemifConfig, callbacks *MemifCallbacks) (memif *Mem
 	// - buffer size
 	args.buffer_size = C.uint16_t(config.BufferSize)
 	// - log_2(ring size)
-	args.log2_ring_size = C.memif_log2_ring_size_t(config.Log2RingSize)
+	args.log2_ring_size = C.uint8_t(config.Log2RingSize)
 
 	// Create memif in C-libmemif.
 	errCode := C.govpp_memif_create(&memif.cHandle, args, unsafe.Pointer(uintptr(memif.ifIndex)))
@@ -757,7 +753,7 @@ func (memif *Memif) TxBurst(queueID uint8, packets []RawPacketData) (count uint1
 	// Allocate ring slots.
 	cQueueID := C.uint16_t(queueID)
 	errCode := C.memif_buffer_alloc(memif.cHandle, cQueueID, pb.buffers, C.uint16_t(bufCount),
-		&allocated, C.uint16_t(bufSize))
+		&allocated, C.uint32_t(bufSize))
 	err = getMemifError(int(errCode))
 	if err == ErrNoBufRing {
 		// Not enough ring slots, <count> will be less than bufCount.
@@ -793,7 +789,6 @@ func (memif *Memif) TxBurst(queueID uint8, packets []RawPacketData) (count uint1
 // Rx queue.
 func (memif *Memif) RxBurst(queueID uint8, count uint16) (packets []RawPacketData, err error) {
 	var recvCount C.uint16_t
-	var freed C.uint16_t
 
 	if count == 0 {
 		return packets, nil
@@ -836,7 +831,9 @@ func (memif *Memif) RxBurst(queueID uint8, count uint16) (packets []RawPacketDat
 		packets = append(packets, C.GoBytes(packetData, packetSize))
 	}
 
-	errCode = C.memif_buffer_free(memif.cHandle, cQueueID, pb.buffers, recvCount, &freed)
+	if recvCount > 0 {
+		errCode = C.memif_refill_queue(memif.cHandle, cQueueID, recvCount, 0)
+	}
 	err = getMemifError(int(errCode))
 	if err != nil {
 		// Throw away packets to avoid duplicities.
@@ -895,6 +892,13 @@ func (memif *Memif) initQueues() error {
 	// Initialize Rx/Tx packet buffers.
 	for i = 0; i < len(details.RxQueues); i++ {
 		memif.rxQueueBufs = append(memif.rxQueueBufs, CPacketBuffers{})
+		if !memif.IsMaster {
+			errCode := C.memif_refill_queue(memif.cHandle, C.uint16_t(i), C.uint16_t(memif.ringSize-1), 0)
+			err = getMemifError(int(errCode))
+			if err != nil {
+				log.Warn(err.Error())
+			}
+		}
 	}
 	for i = 0; i < len(details.TxQueues); i++ {
 		memif.txQueueBufs = append(memif.txQueueBufs, CPacketBuffers{})

--- a/extras/libmemif/examples/gopacket/gopacket.go
+++ b/extras/libmemif/examples/gopacket/gopacket.go
@@ -1,0 +1,166 @@
+// gopacket is simple example how to use alternative method of using gopacket calls and packet handles
+// to implement simple use-case that is shown in raw-data. For more informations check raw-data example.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+
+	"git.fd.io/govpp.git/extras/libmemif"
+	"io"
+)
+
+const (
+	Socket             = "/tmp/gopacket-example"
+	Secret             = "secret"
+	ConnectionID       = 1
+	NumQueues    uint8 = 3
+)
+
+var stopCh chan struct{}
+
+func OnConnect(memif *libmemif.Memif) (err error) {
+	details, err := memif.GetDetails()
+
+	if err != nil {
+		fmt.Printf("libmemif.GetDetails() error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("memif %s has been connected: %+v\n", memif.IfName, details)
+
+	stopCh = make(chan struct{})
+
+	for _, queue := range details.RxQueues {
+		ch, err := memif.GetQueueInterruptChan(queue.QueueID)
+		if err != nil {
+			continue
+		}
+
+		go ReadPackets(memif.NewPacketHandle(queue.QueueID, 3), ch)
+	}
+
+	for _, queue := range details.TxQueues {
+		go SendPackets(memif.NewPacketHandle(queue.QueueID, 3))
+	}
+
+	return nil
+}
+
+func OnDisconnect(memif *libmemif.Memif) (err error) {
+	fmt.Printf("memif %s has been disconnected\n", memif.IfName)
+	close(stopCh)
+	return nil
+}
+
+func ReadPackets(handle libmemif.MemifPacketHandle, interruptCh <-chan struct{}) {
+	for {
+		select {
+		case <-interruptCh:
+		read:
+			for {
+				data, _, err := handle.ReadPacketData()
+
+				switch err {
+				case io.EOF:
+					break read
+				case nil:
+					fmt.Printf("Received packet %v\n", string(data[:]))
+				default:
+					fmt.Printf("Got error while reading packet %v\n", err)
+				}
+			}
+		case <-stopCh:
+			handle.Close()
+			return
+		}
+	}
+}
+
+func SendPackets(handle libmemif.MemifPacketHandle) {
+	counter := 0
+
+	for {
+		select {
+		case <-time.After(3 * time.Second):
+			counter++
+
+			// Prepare fake packets.
+			packets := [][]byte{
+				[]byte("Packet #1 in burst number " + strconv.Itoa(counter)),
+				[]byte("Packet #2 in burst number " + strconv.Itoa(counter)),
+				[]byte("Packet #3 in burst number " + strconv.Itoa(counter)),
+			}
+
+		write:
+			for _, data := range packets {
+				err := handle.WritePacketData(data)
+
+				switch err {
+				case io.EOF:
+					break write
+				case nil:
+					fmt.Printf("Sent packet %v\n", string(data[:]))
+				default:
+					fmt.Printf("Got error while sending packet %v\n", err)
+				}
+			}
+		case <-stopCh:
+			handle.Close()
+			return
+		}
+	}
+}
+
+func main() {
+	var isMaster = true
+	var appSuffix string
+	if len(os.Args) > 1 && (os.Args[1] == "--slave" || os.Args[1] == "-slave") {
+		isMaster = false
+		appSuffix = "-slave"
+	}
+
+	appName := "gopacket" + appSuffix
+	err := libmemif.Init(appName)
+	if err != nil {
+		fmt.Printf("libmemif.Init() error: %v\n", err)
+		return
+	}
+
+	defer libmemif.Cleanup()
+
+	memifCallbacks := &libmemif.MemifCallbacks{
+		OnConnect:    OnConnect,
+		OnDisconnect: OnDisconnect,
+	}
+
+	memifConfig := &libmemif.MemifConfig{
+		MemifMeta: libmemif.MemifMeta{
+			IfName:         "memif1",
+			ConnID:         ConnectionID,
+			SocketFilename: Socket,
+			Secret:         Secret,
+			IsMaster:       isMaster,
+			Mode:           libmemif.IfModeEthernet,
+		},
+		MemifShmSpecs: libmemif.MemifShmSpecs{
+			NumRxQueues: NumQueues,
+			NumTxQueues: NumQueues,
+		},
+	}
+
+	memif, err := libmemif.CreateInterface(memifConfig, memifCallbacks)
+	if err != nil {
+		fmt.Printf("libmemif.CreateInterface() error: %v\n", err)
+		return
+	}
+
+	defer memif.Close()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	<-sigChan
+}

--- a/extras/libmemif/examples/icmp-responder/icmp-responder.go
+++ b/extras/libmemif/examples/icmp-responder/icmp-responder.go
@@ -3,9 +3,10 @@
 // and construct packets.
 //
 // The appropriate VPP configuration for the opposite memif is:
-//   vpp$ create memif id 1 socket /tmp/icmp-responder-example slave secret secret
-//   vpp$ set int state memif0/1 up
-//   vpp$ set int ip address memif0/1 192.168.1.2/24
+//   vpp$ create memif socket id 1 filename /tmp/icmp-responder-example
+//   vpp$ create interface memif id 1 socket-id 1 slave secret secret no-zero-copy
+//   vpp$ set int state memif1/1 up
+//   vpp$ set int ip address memif1/1 192.168.1.2/24
 //
 // To start the example, simply type:
 //   root$ ./icmp-responder

--- a/extras/libmemif/examples/jumbo-frames/jumbo-frames.go
+++ b/extras/libmemif/examples/jumbo-frames/jumbo-frames.go
@@ -1,0 +1,175 @@
+// jumbo-frames is simple example how to send larger and larger jumbo packets with libmemif adapter. This is simple copy
+// or raw-data but with sending larger packets, so for more information read its code and docs.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+
+	"git.fd.io/govpp.git/extras/libmemif"
+)
+
+const (
+	Socket             = "/tmp/jumbo-frames-example"
+	Secret             = "secret"
+	ConnectionID       = 1
+	NumQueues    uint8 = 3
+)
+
+var wg sync.WaitGroup
+var stopCh chan struct{}
+
+func OnConnect(memif *libmemif.Memif) (err error) {
+	details, err := memif.GetDetails()
+	if err != nil {
+		fmt.Printf("libmemif.GetDetails() error: %v\n", err)
+	}
+	fmt.Printf("memif %s has been connected: %+v\n", memif.IfName, details)
+
+	stopCh = make(chan struct{})
+	var i uint8
+	for i = 0; i < uint8(len(details.RxQueues)); i++ {
+		wg.Add(1)
+		go ReadAndPrintPackets(memif, i)
+	}
+	for i = 0; i < uint8(len(details.TxQueues)); i++ {
+		wg.Add(1)
+		go SendPackets(memif, i)
+	}
+	return nil
+}
+
+func OnDisconnect(memif *libmemif.Memif) (err error) {
+	fmt.Printf("memif %s has been disconnected\n", memif.IfName)
+	close(stopCh)
+	wg.Wait()
+	return nil
+}
+
+func ReadAndPrintPackets(memif *libmemif.Memif, queueID uint8) {
+	defer wg.Done()
+
+	interruptCh, err := memif.GetQueueInterruptChan(queueID)
+	if err != nil {
+		switch err {
+		case libmemif.ErrQueueID:
+			fmt.Printf("libmemif.Memif.GetQueueInterruptChan() complains about invalid queue id!?")
+		default:
+			fmt.Printf("libmemif.Memif.GetQueueInterruptChan() error: %v\n", err)
+		}
+		return
+	}
+
+	counter := 0
+	for {
+		select {
+		case <-interruptCh:
+			counter++
+			for {
+				packets, err := memif.RxBurst(queueID, 80)
+				if err != nil {
+					fmt.Printf("libmemif.Memif.RxBurst() error: %v\n", err)
+				} else {
+					if len(packets) == 0 {
+						break
+					}
+					for _, packet := range packets {
+						fmt.Printf("Received packet queue=%d: %v in burst %d\n", queueID, len(packet), counter)
+					}
+				}
+			}
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func SendPackets(memif *libmemif.Memif, queueID uint8) {
+	defer wg.Done()
+
+	counter := 0
+	for {
+		select {
+		case <-time.After(3 * time.Second):
+			counter++
+			packets := []libmemif.RawPacketData{
+				make([]byte, 256*counter),
+				make([]byte, 512*counter),
+				make([]byte, 1024*counter),
+			}
+			sent := 0
+			for {
+				count, err := memif.TxBurst(queueID, packets[sent:])
+				if err != nil {
+					fmt.Printf("libmemif.Memif.TxBurst() error: %v\n", err)
+					break
+				} else {
+					fmt.Printf("libmemif.Memif.TxBurst() has sent %d packets in burst %v.\n", count, counter)
+					sent += int(count)
+					if sent == len(packets) {
+						break
+					}
+				}
+			}
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func main() {
+	var isMaster = true
+	var appSuffix string
+	if len(os.Args) > 1 && (os.Args[1] == "--slave" || os.Args[1] == "-slave") {
+		isMaster = false
+		appSuffix = "-slave"
+	}
+
+	appName := "jumbo-frames" + appSuffix
+	fmt.Println("Initializing libmemif as ", appName)
+	err := libmemif.Init(appName)
+	if err != nil {
+		fmt.Printf("libmemif.Init() error: %v\n", err)
+		return
+	}
+	defer libmemif.Cleanup()
+
+	memifCallbacks := &libmemif.MemifCallbacks{
+		OnConnect:    OnConnect,
+		OnDisconnect: OnDisconnect,
+	}
+
+	memifConfig := &libmemif.MemifConfig{
+		MemifMeta: libmemif.MemifMeta{
+			IfName:         "memif1",
+			ConnID:         ConnectionID,
+			SocketFilename: Socket,
+			Secret:         Secret,
+			IsMaster:       isMaster,
+			Mode:           libmemif.IfModeEthernet,
+		},
+		MemifShmSpecs: libmemif.MemifShmSpecs{
+			NumRxQueues:  NumQueues,
+			NumTxQueues:  NumQueues,
+			BufferSize:   2048,
+			Log2RingSize: 10,
+		},
+	}
+
+	fmt.Printf("Callbacks: %+v\n", memifCallbacks)
+	fmt.Printf("Config: %+v\n", memifConfig)
+
+	memif, err := libmemif.CreateInterface(memifConfig, memifCallbacks)
+	if err != nil {
+		fmt.Printf("libmemif.CreateInterface() error: %v\n", err)
+		return
+	}
+	defer memif.Close()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	<-sigChan
+}

--- a/extras/libmemif/packethandle.go
+++ b/extras/libmemif/packethandle.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libmemif
+
+import (
+	"github.com/google/gopacket"
+	"time"
+	"sync"
+	"io"
+)
+
+type memoizedPacket struct {
+	data RawPacketData
+	co   gopacket.CaptureInfo
+}
+
+type MemifPacketHandle struct {
+	memif   *Memif
+	queueId uint8
+	rxCount uint16
+
+	// Used for caching packets when larger rxburst is called
+	packetQueue []*memoizedPacket
+
+	// Used for synchronization of read/write calls
+	readMu  sync.Mutex
+	writeMu sync.Mutex
+	closeMu sync.Mutex
+	stop    bool
+}
+
+// Create new GoPacket packet handle from libmemif queue. rxCount determines how many packets will be read
+// at once, minimum value is 1
+func (memif *Memif) NewPacketHandle(queueId uint8, rxCount uint16) MemifPacketHandle {
+	if rxCount == 0 {
+		rxCount = 1
+	}
+
+	return MemifPacketHandle{
+		memif:   memif,
+		queueId: queueId,
+		rxCount: rxCount,
+	}
+}
+
+// Reads packet data from memif in bursts, based on previously configured rxCount parameterer. Then caches the
+// resulting packets and returns them 1 by 1 from this method until queue is empty then tries to call new rx burst
+// to read more data. If no data is returned, io.EOF error is thrown and caller should stop reading.
+func (handle *MemifPacketHandle) ReadPacketData() (data []byte, co gopacket.CaptureInfo, err error) {
+	handle.readMu.Lock()
+	defer handle.readMu.Unlock()
+
+	if handle.stop {
+		err = io.EOF
+		return
+	}
+
+	queueLen := len(handle.packetQueue)
+
+	if queueLen == 0 {
+		packets, burstErr := handle.memif.RxBurst(handle.queueId, handle.rxCount)
+		packetsLen := len(packets)
+
+		if burstErr == nil && packetsLen == 0 {
+			err = io.EOF
+			return
+		}
+
+		handle.packetQueue = make([]*memoizedPacket, packetsLen)
+
+		for i, packet := range packets {
+			packetLen := len(packet)
+
+			handle.packetQueue[i] = &memoizedPacket{
+				data: []byte(packet),
+				co: gopacket.CaptureInfo{
+					Timestamp:     time.Now(),
+					CaptureLength: packetLen,
+					Length:        packetLen,
+				},
+			}
+		}
+	}
+
+	packet := handle.packetQueue[0]
+	handle.packetQueue = handle.packetQueue[1:]
+	data = packet.data
+	co = packet.co
+
+	return
+}
+
+// Writes packet data to memif in burst of 1 packet. In case no packet is sent, this method throws io.EOF error and
+// called should stop trying to write packets.
+func (handle *MemifPacketHandle) WritePacketData(data []byte) (err error) {
+	handle.writeMu.Lock()
+	defer handle.writeMu.Unlock()
+
+	if handle.stop {
+		err = io.EOF
+		return
+	}
+
+	count, err := handle.memif.TxBurst(handle.queueId, []RawPacketData{data})
+
+	if err != nil {
+		return
+	}
+
+	if count == 0 {
+		err = io.EOF
+	}
+
+	return
+}
+
+// Waits for all read and write operations to finish and then prevents more from occurring. Handle can be closed only
+// once and then can never be opened again.
+func (handle *MemifPacketHandle) Close() {
+	handle.closeMu.Lock()
+	defer handle.closeMu.Unlock()
+
+	// wait for packet reader to stop
+	handle.readMu.Lock()
+	defer handle.readMu.Unlock()
+
+	// wait for packet writer to stop
+	handle.writeMu.Lock()
+	defer handle.writeMu.Unlock()
+
+	// stop reading and writing
+	handle.stop = true
+}


### PR DESCRIPTION
Add support for frames larger than maximum buffer size to libmemif
adapter.

Depends on #2 

Todo:
* [ ] Optimize copying and splitting of packet data - move splitting to govpp_copy_packet_data using pointers to chunks
* [ ] Add support for chaining jumbo frames in RxBurst by caching previous unfinished jumbo frame and appending to it next read if needed
* [ ] Merge govpp_move_buffers_by and memif_buffer_alloc calls into one method that will allocate buffers and return pointer to next free buffer