### PR TITLE
Fixing compilation failure of adapter.go

### DIFF
--- a/extras/libmemif/adapter.go
+++ b/extras/libmemif/adapter.go
@@ -474,11 +474,11 @@ func Init(appName string) error {
 	// Initialize C-libmemif.
 	var errCode int
 	if appName == "" {
-		errCode = int(C.memif_init(nil, nil, nil, nil))
+		errCode = int(C.memif_init(nil, nil, nil, nil, nil))
 	} else {
 		appName := C.CString(appName)
 		defer C.free(unsafe.Pointer(appName))
-		errCode = int(C.memif_init(nil, appName, nil, nil))
+		errCode = int(C.memif_init(nil, appName, nil, nil, nil))
 	}
 	err := getMemifError(errCode)
 	if err != nil {


### PR DESCRIPTION
building memif example was failing with the following error:
```go
go build
# git.fd.io/govpp.git/extras/libmemif
../../../git.fd.io/govpp.git/extras/libmemif/adapter.go:477: not enough arguments in call to _Cfunc_memif_init
        have (nil, nil, nil, nil)
        want (*_Ctype_memif_control_fd_update_t, *_Ctype_char, *_Ctype_memif_alloc_t, *_Ctype_memif_realloc_t, *_Ctype_memif_free_t)
../../../git.fd.io/govpp.git/extras/libmemif/adapter.go:481: not enough arguments in call to _Cfunc_memif_init
        have (nil, *_Ctype_char, nil, nil)
        want (*_Ctype_memif_control_fd_update_t, *_Ctype_char, *_Ctype_memif_alloc_t, *_Ctype_memif_realloc_t, *_Ctype_memif_free_t)
```
This PR fixes compilation process by adding missing arguments.

Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>