### PR TITLE
Exposed input_queue_size argument to user

### DIFF
--- a/adapter/vppapiclient/vppapiclient_stub.go
+++ b/adapter/vppapiclient/vppapiclient_stub.go
@@ -28,6 +28,10 @@ func NewVppClient(string) adapter.VppAPI {
 	return &stubVppClient{}
 }
 
+func NewVppClientWithInputQueueSize(string, uint16) adapter.VppAPI {
+	return &stubVppClient{}
+}
+
 func (a *stubVppClient) Connect() error {
 	return adapter.ErrNotImplemented
 }


### PR DESCRIPTION
In large-scale deployments with a high number of interfaces, small values of `rx_len` (a.k.a. `input_queue_size`) cause VPP to eventually hang.
This pull request exposes input queue size to end user.