### PR TITLE
add MockClearReplyHandlers() api for mock vpp adapter 

### DIFF
--- a/adapter/mock/mock_vpp_adapter.go
+++ b/adapter/mock/mock_vpp_adapter.go
@@ -176,7 +176,6 @@ func (a *VppAdapter) ReplyBytes(request MessageDTO, reply api.Message) ([]byte, 
 			" ", err)
 		return nil, err
 	}
-	log.Println("ReplyBytes ", replyMsgID, " ", reply.GetMessageName(), " clientId: ", request.ClientID)
 
 	buf := new(bytes.Buffer)
 	err = struc.Pack(buf, &codec.VppReplyHeader{

--- a/adapter/mock/mock_vpp_adapter.go
+++ b/adapter/mock/mock_vpp_adapter.go
@@ -372,6 +372,15 @@ func (a *VppAdapter) MockReplyHandler(replyHandler ReplyHandler) {
 	a.mode = useReplyHandlers
 }
 
+// MockClearReplyHandlers clears all reply Handlers that were registered so far
+func (a *VppAdapter) MockClearReplyHandlers() {
+	a.repliesLock.Lock()
+	defer a.repliesLock.Unlock()
+
+	a.replyHandlers = a.replyHandlers[:0]
+	a.mode = useReplyHandlers
+}
+
 func setSeqNum(context uint32, seqNum uint16) (newContext uint32) {
 	context &= 0xffff0000
 	context |= uint32(seqNum)


### PR DESCRIPTION
When writing tests - each tests requires a different reply handler - this api provides a way to clear all existing reply handlers. If needed, can introduce another api to remove a specific reply handler..

Also removed an un-necessary log message.