### PR TITLE
cmd/binapi-generator: run code through gofmt

### DIFF
--- a/cmd/binapi-generator/generate.go
+++ b/cmd/binapi-generator/generate.go
@@ -243,13 +243,16 @@ func generateHeader(ctx *context, w io.Writer) {
 }
 
 func generateImports(ctx *context, w io.Writer) {
-	fmt.Fprintln(w, "import (")
-	fmt.Fprintf(w, "\tapi \"%s\"\n", govppApiImportPath)
-	fmt.Fprintf(w, "\tbytes \"%s\"\n", "bytes")
-	fmt.Fprintf(w, "\tcontext \"%s\"\n", "context")
-	fmt.Fprintf(w, "\tio \"%s\"\n", "io")
-	fmt.Fprintf(w, "\tstrconv \"%s\"\n", "strconv")
-	fmt.Fprintf(w, "\tstruc \"%s\"\n", "github.com/lunixbochs/struc")
+	fmt.Fprintf(w,
+		`import (
+	"bytes"
+	"context"
+	"io"
+	"strconv"
+
+	"github.com/lunixbochs/struc"
+	api %q
+`, govppApiImportPath)
 	if len(ctx.packageData.Imports) > 0 {
 		fmt.Fprintln(w)
 		for _, imp := range getImports(ctx) {

--- a/cmd/binapi-generator/main.go
+++ b/cmd/binapi-generator/main.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -209,6 +210,10 @@ func generateFromFile(inputFile, outputDir string, typesPkgs []*context) error {
 	if err := generatePackage(ctx, &buf); err != nil {
 		return fmt.Errorf("generating code for package %s failed: %v", ctx.packageName, err)
 	}
+	gosrc, err := format.Source(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("gofmt for package %s failed: %v", ctx.packageName, err)
+	}
 
 	// create output directory
 	packageDir := filepath.Dir(ctx.outputFile)
@@ -216,7 +221,7 @@ func generateFromFile(inputFile, outputDir string, typesPkgs []*context) error {
 		return fmt.Errorf("creating output dir %s failed: %v", packageDir, err)
 	}
 	// write generated code to output file
-	if err := ioutil.WriteFile(ctx.outputFile, buf.Bytes(), 0666); err != nil {
+	if err := ioutil.WriteFile(ctx.outputFile, gosrc, 0666); err != nil {
 		return fmt.Errorf("writing to output file %s failed: %v", ctx.outputFile, err)
 	}
 


### PR DESCRIPTION
Currently the Go source code generated by binapi-generator puts the Go
imports in a random order, so any run through gofmt generates
a changed file. Fix this by running source code through gofmt before
writing it to disk.