### PR TITLE
Fix mmap

### DIFF
--- a/adapter/statsclient/statsclient.go
+++ b/adapter/statsclient/statsclient.go
@@ -367,6 +367,9 @@ func (sc *StatsClient) connect() (ss statSegment, err error) {
 	case 2:
 		ss = newStatSegmentV2(sc.headerData, size)
 	default:
+		if err = syscall.Munmap(sc.headerData); err != nil {
+			Log.Debugf("unmapping shared memory failed: %v", err)
+		}
 		return nil, fmt.Errorf("stat segment version is not supported: %v (min: %v, max: %v)",
 			version, minVersion, maxVersion)
 	}


### PR DESCRIPTION
I use the v0.3.5 version statsclient on production for monitoring, and I found some testing cases failed in my testing environment because of the monitor agent's memory leak. Code below is how I use statsclient.StatsClient before:
```
// run on one single goroutine
client := statsclient.NewStatsClient("")
err := client.Connect()
if err != nil {
    // got err due to fail to check stat segment version
    // if return here, StatsClient.shareHeader is still mmap into this progress
    // and that cause memory leak
    log(err)
    return err
}
defer client.Disconnect()
```

After a memory leak happened due to a failure in checking stat segment version, I had to write code like this:
```
client := statsclient.NewStatsClient("")
connectErr := client.Connect()
// ensure it will call Disconnect no matter there is a error or not, 
// even though a failure in checking stat version
defer func() {
    disconnectErr = client.Disconnect()
    if disconnectErr != nil {
        log(err)
    }
}
if connectErr != nil {
    log(err)
}
```

I was thinking why not solve this at the root?  So I open this PR to solve that problem.