### PR TITLE
Introducing ChannelProvidingConnection

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -70,6 +70,12 @@ type ChannelProvider interface {
 	NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize int) (Channel, error)
 }
 
+// ChannelProvidingConnection provides both the Connection and ChannelProvider interface
+type ChannelProvidingConnection interface {
+	Connection
+	ChannelProvider
+}
+
 // Channel provides methods for direct communication with VPP channel.
 type Channel interface {
 	// SendRequest asynchronously sends a request to VPP. Returns a request context, that can be used to call ReceiveReply.


### PR DESCRIPTION
api.Connection is a very convenient interface for using
the RPC style binapi

Unfortunately, in order to Subscribe to Events like
interfaces.SwInterfaceEvent{} you have to have an api.Channel
against which you can call SubscribeNotification

Conveniently, core.Connection implements both api.Connection and
api.ChannelProvider.

Unfortunately,  we have no type with which a function can indicate
it requires *both* of those interfaces.

ChannelProvidingConnection implements both api.ChannelProvider and
api.Connection allowing it to be used as a parameter to functions
which require an argument that implements both.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
