### PR TITLE
feat: Disable default reply timeout

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -86,8 +86,9 @@ type Channel interface {
 	// buffer is full, the notifications will not be delivered into it.
 	SubscribeNotification(notifChan chan Message, event Message) (SubscriptionCtx, error)
 
-	// SetReplyTimeout sets the timeout for replies from VPP. It represents the maximum time the API waits for a reply
-	// from VPP before returning an error.
+	// SetReplyTimeout sets the timeout for replies from VPP. It represents the maximum time the client waits for a reply
+	// from VPP before returning a timeout error. Setting the reply timeout to 0 disables it. The initial reply timeout is
+	//set to the value of core.DefaultReplyTimeout.
 	SetReplyTimeout(timeout time.Duration)
 
 	// CheckCompatibility checks the compatiblity for the given messages.

--- a/core/connection.go
+++ b/core/connection.go
@@ -47,7 +47,7 @@ var (
 	HealthCheckProbeInterval = time.Second            // default health check probe interval
 	HealthCheckReplyTimeout  = time.Millisecond * 250 // timeout for reply to a health check probe
 	HealthCheckThreshold     = 2                      // number of failed health checks until the error is reported
-	DefaultReplyTimeout      = time.Second            // default timeout for replies from VPP
+	DefaultReplyTimeout      = time.Duration(0)       // default timeout for replies from VPP is disabled
 )
 
 // ConnectionState represents the current state of the connection to VPP.

--- a/core/connection.go
+++ b/core/connection.go
@@ -25,11 +25,10 @@ import (
 
 	logger "github.com/sirupsen/logrus"
 
-	"go.fd.io/govpp/core/genericpool"
-
 	"go.fd.io/govpp/adapter"
 	"go.fd.io/govpp/api"
 	"go.fd.io/govpp/codec"
+	"go.fd.io/govpp/core/genericpool"
 )
 
 const (
@@ -47,7 +46,11 @@ var (
 	HealthCheckProbeInterval = time.Second            // default health check probe interval
 	HealthCheckReplyTimeout  = time.Millisecond * 250 // timeout for reply to a health check probe
 	HealthCheckThreshold     = 2                      // number of failed health checks until the error is reported
-	DefaultReplyTimeout      = time.Duration(0)       // default timeout for replies from VPP is disabled
+)
+
+var (
+	DefaultReplyTimeout   = time.Duration(0) // default timeout for replies from VPP is disabled
+	WarnSlowReplyDuration = time.Second * 1  // duration of slow replies after which a warning is printed
 )
 
 // ConnectionState represents the current state of the connection to VPP.


### PR DESCRIPTION
This PR adds support for disabling the reply timeout by setting it to `0`. Also, it disables the default reply timeout.