### PR TITLE
Prevent data race on msgMapByPath map

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -379,8 +379,11 @@ func compareSeqNumbers(seqNum1, seqNum2 uint16) int {
 	return 1
 }
 
-// Returns message based on the message ID not depending on message path
+// Returns message based on the message ID not depending on message path.
 func (c *Connection) getMessageByID(msgID uint16) (msg api.Message, err error) {
+	c.msgMapByPathLock.RLock()
+	defer c.msgMapByPathLock.RUnlock()
+
 	var ok bool
 	for _, messages := range c.msgMapByPath {
 		if msg, ok = messages[msgID]; ok {


### PR DESCRIPTION
```
==================                                                                                                                                                           
 WARNING: DATA RACE                                                                                                                                                           
 Read at 0x00c00041f290 by goroutine 17:                                                                                                                                      
   runtime.mapaccess2_faststr()                                                                                                                                               
       /usr/local/go/src/runtime/map_faststr.go:108 +0x0                                                                                                                      
   race-project/vendor/git.fd.io/govpp.git/core.(*Connection).GetMessageID()                                                                              
       race-project/vendor/git.fd.io/govpp.git/core/connection.go:420 +0x15c                                                                              
   race-project/vendor/git.fd.io/govpp.git/core.(*Connection).processRequest()                                                                            
       race-project/vendor/git.fd.io/govpp.git/core/request_handler.go:73 +0x48e                                                                          
   race-project/vendor/git.fd.io/govpp.git/core.(*Connection).watchRequests()                                                                             
       race-project/vendor/git.fd.io/govpp.git/core/request_handler.go:47 +0x9e                                                                           
   race-project/vendor/git.fd.io/govpp.git/core.(*Connection).newAPIChannel.func1()                                                                       
       race-project/vendor/git.fd.io/govpp.git/core/connection.go:261 +0x47                                                                               
 Previous write at 0x00c00041f290 by goroutine 75:                                                                                                                            
   runtime.mapassign_faststr()                                                                                                                                                
       /usr/local/go/src/runtime/map_faststr.go:203 +0x0                                                                                                                      
   race-project/vendor/git.fd.io/govpp.git/core.(*Connection).GetMessageID()                                                                              
       race-project/vendor/git.fd.io/govpp.git/core/connection.go:421 +0x2af                                                                              
   race-project/vendor/git.fd.io/govpp.git/core.(*Channel).CheckCompatiblity()                                                                            
       race-project/vendor/git.fd.io/govpp.git/core/channel.go:176 +0x187                                                                                 
   race-project/cloudgate/vpp/govpp.(*Channel).CheckCompatibility()                                                                                       
       race-project/cloudgate/vpp/govpp/channel.go:32 +0x9b
```