### PR TITLE
Fix panic on the pool put/get operations

### DIFF
--- a/core/channel_test.go
+++ b/core/channel_test.go
@@ -190,7 +190,7 @@ func TestSetReplyTimeout(t *testing.T) {
 	ctx := setupTest(t)
 	defer ctx.teardownTest()
 
-	ctx.ch.SetReplyTimeout(time.Millisecond)
+	ctx.ch.SetReplyTimeout(time.Millisecond * 10)
 
 	// mock reply
 	ctx.mockVpp.MockReply(&ControlPingReply{})
@@ -343,7 +343,7 @@ func TestReceiveReplyAfterTimeout(t *testing.T) {
 	ctx := setupTest(t)
 	defer ctx.teardownTest()
 
-	ctx.ch.SetReplyTimeout(time.Millisecond)
+	ctx.ch.SetReplyTimeout(time.Millisecond * 10)
 
 	// mock reply
 	ctx.mockVpp.MockReplyWithContext(mock.MsgWithContext{Msg: &ControlPingReply{}, SeqNum: 1})


### PR DESCRIPTION
 
* Fix panic of interface conversion
    
    The previous commit fd89a9 added extra & on 'put' to the pool.
    This was the reason of panic on 'get' method:
    panic: interface conversion: interface {} is **[]uint8, not *[]uint8

* Increase reply timeout on tests 
    One millisecond timeout is not enough for ci, increase it to prevent flaps.
    
