### PR TITLE
Fix endless loop in Reset

### DIFF
--- a/core/channel.go
+++ b/core/channel.go
@@ -377,18 +377,23 @@ func (ch *Channel) processReply(reply *vppReply, expSeqNum uint16, msg api.Messa
 }
 
 func (ch *Channel) Reset() {
+	if len(ch.reqChan) > 0 || len(ch.replyChan) > 0 {
+		log.WithField("channel", ch.id).Debugf("draining channel buffers (req: %d, reply: %d)", len(ch.reqChan), len(ch.replyChan))
+	}
 	// Drain any lingering items in the buffers
-	empty := false
-	for !empty {
+	for empty := false; !empty; {
+		// channels must be set to nil when closed to prevent
+		// select below to always run the case immediatelly
+		// which would make the loop run forever
 		select {
 		case _, ok := <-ch.reqChan:
 			if !ok {
-				// must set reqChan to nil when it gets closed
-				// to prevent selecting this case instantly
-				// and running this loop forever
 				ch.reqChan = nil
 			}
-		case <-ch.replyChan:
+		case _, ok := <-ch.replyChan:
+			if !ok {
+				ch.replyChan = nil
+			}
 		default:
 			empty = true
 		}

--- a/core/channel.go
+++ b/core/channel.go
@@ -381,7 +381,13 @@ func (ch *Channel) Reset() {
 	empty := false
 	for !empty {
 		select {
-		case <-ch.reqChan:
+		case _, ok := <-ch.reqChan:
+			if !ok {
+				// must set reqChan to nil when it gets closed
+				// to prevent selecting this case instantly
+				// and running this loop forever
+				ch.reqChan = nil
+			}
 		case <-ch.replyChan:
 		default:
 			empty = true

--- a/core/channel_test.go
+++ b/core/channel_test.go
@@ -48,7 +48,14 @@ func setupTest(t *testing.T) *testCtx {
 	ctx.ch, err = ctx.conn.NewAPIChannel()
 	Expect(err).ShouldNot(HaveOccurred())
 
+	ctx.resetReplyTimeout()
+
 	return ctx
+}
+
+func (ctx *testCtx) resetReplyTimeout() {
+	// setting reply timeout to non-zero value to fail fast on potential deadlocks
+	ctx.ch.SetReplyTimeout(time.Second * 5)
 }
 
 func (ctx *testCtx) teardownTest() {
@@ -190,14 +197,14 @@ func TestSetReplyTimeout(t *testing.T) {
 	ctx := setupTest(t)
 	defer ctx.teardownTest()
 
-	ctx.ch.SetReplyTimeout(time.Millisecond * 10)
-
 	// mock reply
 	ctx.mockVpp.MockReply(&ControlPingReply{})
 
 	// first one request should work
 	err := ctx.ch.SendRequest(&ControlPing{}).ReceiveReply(&ControlPingReply{})
 	Expect(err).ShouldNot(HaveOccurred())
+
+	ctx.ch.SetReplyTimeout(time.Millisecond * 1)
 
 	// no other reply ready - expect timeout
 	err = ctx.ch.SendRequest(&ControlPing{}).ReceiveReply(&ControlPingReply{})
@@ -208,8 +215,6 @@ func TestSetReplyTimeout(t *testing.T) {
 func TestSetReplyTimeoutMultiRequest(t *testing.T) {
 	ctx := setupTest(t)
 	defer ctx.teardownTest()
-
-	ctx.ch.SetReplyTimeout(time.Millisecond * 100)
 
 	// mock reply
 	ctx.mockVpp.MockReply(
@@ -248,6 +253,8 @@ func TestSetReplyTimeoutMultiRequest(t *testing.T) {
 	// first one request should work
 	err := sendMultiRequest()
 	Expect(err).ShouldNot(HaveOccurred())
+
+	ctx.ch.SetReplyTimeout(time.Millisecond * 1)
 
 	// no other reply ready - expect timeout
 	err = sendMultiRequest()
@@ -343,21 +350,23 @@ func TestReceiveReplyAfterTimeout(t *testing.T) {
 	ctx := setupTest(t)
 	defer ctx.teardownTest()
 
-	ctx.ch.SetReplyTimeout(time.Millisecond * 10)
-
 	// mock reply
 	ctx.mockVpp.MockReplyWithContext(mock.MsgWithContext{Msg: &ControlPingReply{}, SeqNum: 1})
-	// first one request should work
 
+	// first request should succeed
 	err := ctx.ch.SendRequest(&ControlPing{}).ReceiveReply(&ControlPingReply{})
 	Expect(err).ShouldNot(HaveOccurred())
 
-	err = ctx.ch.SendRequest(&ControlPing{}).ReceiveReply(&ControlPingReply{})
+	// second request should fail with timeout
+	ctx.ch.SetReplyTimeout(time.Millisecond * 1)
+	req := ctx.ch.SendRequest(&ControlPing{})
+	time.Sleep(time.Millisecond * 2)
+	err = req.ReceiveReply(&ControlPingReply{})
 	Expect(err).Should(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("timeout"))
 
 	ctx.mockVpp.MockReplyWithContext(
-		// simulating late reply
+		// late reply from previous request
 		mock.MsgWithContext{
 			Msg:    &ControlPingReply{},
 			SeqNum: 2,
@@ -369,14 +378,15 @@ func TestReceiveReplyAfterTimeout(t *testing.T) {
 		},
 	)
 
-	req := &interfaces.SwInterfaceSetFlags{
-		SwIfIndex: 1,
-		Flags:     interface_types.IF_STATUS_API_FLAG_ADMIN_UP,
-	}
 	reply := &interfaces.SwInterfaceSetFlagsReply{}
 
-	// should succeed
-	err = ctx.ch.SendRequest(req).ReceiveReply(reply)
+	ctx.resetReplyTimeout()
+
+	// third request should succeed
+	err = ctx.ch.SendRequest(&interfaces.SwInterfaceSetFlags{
+		SwIfIndex: 1,
+		Flags:     interface_types.IF_STATUS_API_FLAG_ADMIN_UP,
+	}).ReceiveReply(reply)
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
@@ -392,14 +402,14 @@ func TestReceiveReplyAfterTimeoutMultiRequest(t *testing.T) {
 	ctx := setupTest(t)
 	defer ctx.teardownTest()
 
-	ctx.ch.SetReplyTimeout(time.Millisecond * 100)
-
 	// mock reply
 	ctx.mockVpp.MockReplyWithContext(mock.MsgWithContext{Msg: &ControlPingReply{}, SeqNum: 1})
 
 	// first one request should work
 	err := ctx.ch.SendRequest(&ControlPing{}).ReceiveReply(&ControlPingReply{})
 	Expect(err).ShouldNot(HaveOccurred())
+
+	ctx.ch.SetReplyTimeout(time.Millisecond * 1)
 
 	cnt := 0
 	var sendMultiRequest = func() error {
@@ -417,11 +427,12 @@ func TestReceiveReplyAfterTimeoutMultiRequest(t *testing.T) {
 		}
 		return nil
 	}
-
 	err = sendMultiRequest()
 	Expect(err).Should(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("timeout"))
 	Expect(cnt).To(BeEquivalentTo(0))
+
+	ctx.resetReplyTimeout()
 
 	// simulating late replies
 	var msgs []mock.MsgWithContext

--- a/core/connection.go
+++ b/core/connection.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	logger "github.com/sirupsen/logrus"
+
 	"go.fd.io/govpp/core/genericpool"
 
 	"go.fd.io/govpp/adapter"
@@ -296,7 +297,7 @@ func (c *Connection) releaseAPIChannel(ch *Channel) {
 	c.channelsLock.Lock()
 	delete(c.channels, ch.id)
 	c.channelsLock.Unlock()
-	c.channelPool.Put(ch)
+	go c.channelPool.Put(ch)
 }
 
 // connectLoop attempts to connect to VPP until it succeeds.

--- a/core/connection_test.go
+++ b/core/connection_test.go
@@ -112,13 +112,6 @@ func TestAsyncConnectionProcessesVppTimeout(t *testing.T) {
 
 	ev := <-statusChan
 	Expect(ev.State).Should(BeEquivalentTo(core.Connected))
-
-	// make control ping reply fail so that connection.healthCheckLoop()
-	// initiates reconnection.
-	/*ctx.mockVpp.MockReply(&memclnt.ControlPingReply{
-	  	Retval: -1,
-	  })
-	  time.Sleep(time.Duration(1+core.HealthCheckThreshold) * (core.HealthCheckInterval + 2*core.HealthCheckReplyTimeout))*/
 }
 
 func TestCodec(t *testing.T) {

--- a/core/genericpool/generic_pool.go
+++ b/core/genericpool/generic_pool.go
@@ -17,12 +17,10 @@ func (p *Pool[T]) Get() T {
 }
 
 func (p *Pool[T]) Put(x T) {
-	go func(p *Pool[T], x T) {
-		if res, ok := any(x).(Resettable); ok {
-			res.Reset()
-		}
-		p.p.Put(x)
-	}(p, x)
+	if res, ok := any(x).(Resettable); ok {
+		res.Reset()
+	}
+	p.p.Put(x)
 }
 
 func New[T any](f func() T) *Pool[T] {


### PR DESCRIPTION
This change fixes a bug where the drain channel loop would run forever. 
This happens when reqChan gets closed which makes the case with closed channel be selected instantly. 
The fix is to set reqChan to nil which practically ignores that case in the select.

