### PR TITLE
Run golangci-lint in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,19 @@
 ---
 name: ci
+
 on:
   push:
+    tags:
+      - v*
     branches:
       - master
+      - ci
   pull_request:
   # Allows running this workflow manually
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   yaml-lint:
@@ -22,13 +29,16 @@ jobs:
           yamllint_strict: true
   
   go-mod:
+    strategy:
+      matrix:
+        go: [1.18, tip]
     name: check go.mod
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.go }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check go mod
@@ -37,16 +47,17 @@ jobs:
           git diff --exit-code go.mod
     
   build-test:
-    name: build and test
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        go: [1.18]
         os: [ubuntu-latest]
+    name: build and test
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.go }}
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@v1.0.0
         with:
@@ -62,3 +73,21 @@ jobs:
         uses: guyarb/golang-test-annotations@v0.6.0
         with:
           test-results: test.json
+  
+  golangci:
+    strategy:
+      matrix:
+        go: [1.18]
+    name: lint go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3  # docs: https://github.com/golangci/golangci-lint-action
+        with:
+          version: v1.29

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
   go-mod:
     strategy:
       matrix:
-        go: [1.18, tip]
+        go: [1.18]
     name: check go.mod
     runs-on: ubuntu-latest
     steps:
@@ -80,6 +80,9 @@ jobs:
         go: [1.18]
     name: lint go
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -90,4 +93,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3  # docs: https://github.com/golangci/golangci-lint-action
         with:
-          version: v1.29
+          version: v1.50
+          args: --go="${{ matrix.go }}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+# Configuration of golangci-lint
+# 
+# see docs: https://golangci-lint.run/usage/configuration/
+
+run:
+  timeout: 5m
+  skip-dirs:
+    - adapter/mock
+  skip-files:
+    - ".*\\.ba.\\.go$"
+
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused


### PR DESCRIPTION
This PR adds new step to CI workflow for running [golangci-lint tool](https://golangci-lint.run/).