### PR TITLE
Add support of watching events to Connection

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -31,6 +31,22 @@ type Connection interface {
 	// It creates stream and calls SendMsg with req and RecvMsg which returns
 	// reply.
 	Invoke(ctx context.Context, req Message, reply Message) error
+
+	// WatchEvent creates a new watcher for watching events of type specified by
+	// event parameter. Context can be used to close the watcher.
+	WatchEvent(ctx context.Context, event Message) (Watcher, error)
+}
+
+// Watcher provides access to watched event messages. It can be created by calling Connection.WatchEvent.
+//
+// NOTE: This API is EXPERIMENTAL.
+type Watcher interface {
+	// Events returns a channel where events are sent. The channel is closed when
+	// watcher context is canceled or when Close is called.
+	Events() <-chan Message
+
+	// Close closes the watcher along with the events channel.
+	Close()
 }
 
 // Stream provides low-level access for sending and receiving messages.
@@ -41,6 +57,9 @@ type Connection interface {
 //
 // NOTE: This API is EXPERIMENTAL.
 type Stream interface {
+	// Context returns the context for this stream.
+	Context() context.Context
+
 	// SendMsg sends a message to the client.
 	// It blocks until message is sent to the transport.
 	SendMsg(Message) error
@@ -53,10 +72,7 @@ type Stream interface {
 	Close() error
 }
 
-// StreamOption allows customizing a Stream. Available options are:
-// - WithRequestSize
-// - WithReplySize
-// - WithReplyTimeout
+// StreamOption allows customizing a Stream.
 type StreamOption func(Stream)
 
 // ChannelProvider provides the communication channel with govpp core.

--- a/core/stream.go
+++ b/core/stream.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"go.fd.io/govpp/api"
 )
 
@@ -87,6 +89,88 @@ func (c *Connection) Invoke(ctx context.Context, req api.Message, reply api.Mess
 		return err
 	}
 	return nil
+}
+
+type watcher struct {
+	conn   *Connection
+	ctx    context.Context
+	sub    *subscriptionCtx
+	events chan api.Message
+	cancel context.CancelFunc
+	quit   chan struct{}
+}
+
+func (w *watcher) Events() <-chan api.Message {
+	return w.events
+}
+
+func (w *watcher) Close() {
+	w.cancel()
+}
+
+func (w *watcher) watch() {
+	log.WithField("event", w.sub.event.GetMessageName()).Debugf("starting event watcher")
+	defer func() {
+		if err := w.sub.Unsubscribe(); err != nil {
+			log.Debugf("watcher unsubscribe error: %v", err)
+		}
+		close(w.events)
+		log.WithField("event", w.sub.event.GetMessageName()).Debugf("event watcher done")
+	}()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case e := <-w.sub.notifChan:
+			// send to events
+			select {
+			case <-w.ctx.Done():
+				return
+			case w.events <- e:
+				// received by events
+			}
+		}
+	}
+}
+
+func (c *Connection) WatchEvent(ctx context.Context, event api.Message) (api.Watcher, error) {
+	msgID, err := c.GetMessageID(event)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"msg_name": event.GetMessageName(),
+			"msg_crc":  event.GetCrcString(),
+		}).Debugf("unable to retrieve event message ID: %v", err)
+		return nil, fmt.Errorf("unable to retrieve event message ID: %v", err)
+	}
+
+	cctx, cancel := context.WithCancel(ctx)
+
+	w := &watcher{
+		conn:   c,
+		ctx:    cctx,
+		cancel: cancel,
+		events: make(chan api.Message),
+		quit:   make(chan struct{}),
+	}
+
+	w.sub = &subscriptionCtx{
+		conn:       c,
+		notifChan:  make(chan api.Message, 10),
+		msgID:      msgID,
+		event:      event,
+		msgFactory: getMsgFactory(event),
+	}
+
+	go w.watch()
+
+	// add the subscription into map
+	c.subscriptionsLock.Lock()
+	defer c.subscriptionsLock.Unlock()
+
+	c.subscriptions[msgID] = append(c.subscriptions[msgID], w.sub)
+
+	return w, nil
 }
 
 func (s *Stream) Context() context.Context {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/bennyscetbun/jsongo v1.1.0 h1:ZDSks3aLP13jhY139lWaUqZaU8G0tELMohzumut/KDM=
 github.com/bennyscetbun/jsongo v1.1.0/go.mod h1:suxbVmjBV8+A2BBAM5EYVh6Uj8j3rqJhzWf3hv7Ff8U=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -26,8 +27,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -135,8 +135,13 @@ type BinapiClient struct {
 
 // RPCStream is a stream for forwarding requests to BinapiRPC's stream.
 type RPCStream struct {
+	ctx context.Context
 	rpc *rpc.Client
 	id  uint32
+}
+
+func (s *RPCStream) Context() context.Context {
+	return s.ctx
 }
 
 func (s *RPCStream) SendMsg(msg api.Message) error {


### PR DESCRIPTION
This PR adds support for event watching to Connection ([Stream API](https://github.com/FDio/govpp/discussions/43)). This initial draft proposal was done by @edwarnicke in #42. However, this PR does not change the generated RPC code in any way for now. 

Quick look at the new API:

```go
type Connection {
	// ...
	WatchEvent(ctx context.Context, event Message) (Watcher, error)
}

type Watcher interface {
	Events() <-chan Message
	Close()
}
```

See the stream-client example for usage details.