### PR TITLE
gomemif: handle EINTR error

### DIFF
--- a/extras/gomemif/README.rst
+++ b/extras/gomemif/README.rst
@@ -17,7 +17,7 @@ To Run ICMP responder in interrupt mode:
 
 ::
 
-   DBGvpp# create interface memif id 0 master no-zero-copy
+   DBGvpp# create interface memif id 0 master
    DBGvpp# set int ip addr memif0/0 192.168.1.2/24
    DBGvpp# set int state memif0/0 up
 
@@ -30,7 +30,7 @@ To Run ICMP responder in polling mode:
 
 ::
 
-   DBGvpp# create interface memif id 0 master no-zero-copy
+   DBGvpp# create interface memif id 0 master
    DBGvpp# set int ip addr memif0/0 192.168.1.2/24
    DBGvpp# set int state memif0/0 up
 

--- a/extras/gomemif/memif/packet_writer.go
+++ b/extras/gomemif/memif/packet_writer.go
@@ -93,3 +93,79 @@ func (q *Queue) WritePacket(pkt []byte) int {
 
 	return n
 }
+
+func (q *Queue) Tx_burst(pkt []MemifPacketBuffer) int {
+	var mask int = q.ring.size - 1
+	var slot int
+	var nFree uint16
+	var packetBufferSize int = int(q.i.run.PacketBufferSize)
+
+	if q.i.args.IsMaster {
+		slot = q.readTail()
+		nFree = uint16(q.readHead() - slot)
+	} else {
+		slot = q.readHead()
+		nFree = uint16(q.ring.size - slot + q.readTail())
+	}
+
+	if nFree == 0 {
+		q.interrupt()
+		return 0
+	}
+
+	var n int
+	for i := 0; i < len(pkt); i++ {
+		// copy descriptor from shm
+		desc := newDescBuf()
+		q.getDescBuf(slot&mask, desc)
+		// reset flags
+		desc.setFlags(0)
+		// reset length
+		if q.i.args.IsMaster {
+			packetBufferSize = desc.getLength()
+		}
+		desc.setLength(0)
+		offset := desc.getOffset()
+		// write packet into memif buffer
+		n = copy(q.i.regions[desc.getRegion()].data[offset:offset+packetBufferSize], pkt[i].Buf[:])
+		desc.setLength(n)
+		for n < len(pkt[i].Buf) {
+			nFree--
+			if nFree == 0 {
+				q.interrupt()
+				return 0
+			}
+			desc.setFlags(descFlagNext)
+			q.putDescBuf(slot&mask, desc)
+			slot++
+
+			// copy descriptor from shm
+			q.getDescBuf(slot&mask, desc)
+			// reset flags
+			desc.setFlags(0)
+			// reset length
+			if q.i.args.IsMaster {
+				packetBufferSize = desc.getLength()
+			}
+			desc.setLength(0)
+			offset := desc.getOffset()
+
+			tmp := copy(q.i.regions[desc.getRegion()].data[offset:offset+packetBufferSize], pkt[i].Buf[:])
+			desc.setLength(tmp)
+			n += tmp
+		}
+
+		// copy descriptor to shm
+		q.putDescBuf(slot&mask, desc)
+		slot++
+	}
+	if q.i.args.IsMaster {
+		q.writeTail(slot)
+	} else {
+		q.writeHead(slot)
+	}
+
+	q.interrupt()
+
+	return n
+}


### PR DESCRIPTION
-Add handling for EINT error
-Fix packet burst
-Fix connection between interfaces in [(intr/intr),(intr,poll),(poll,intr)] modes 
-Fix master interface

Signed-off-by: Daniel Béreš <dberes@cisco.com>