### PR TITLE
Update Go and test if binapi is up-to-date

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
   go-mod:
     strategy:
       matrix:
-        go: [ 1.20 ]
+        go: [ '1.20' ]
     name: check go.mod
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
   binapi:
     strategy:
       matrix:
-        go: [ 1.20 ]
+        go: [ '1.20' ]
     env:
       VERSION: v0.7.0
     name: check binapi
@@ -73,7 +73,7 @@ jobs:
   build-test:
     strategy:
       matrix:
-        go: [ 1.20 ]
+        go: [ '1.20' ]
         os: [ ubuntu-latest ]
     name: build and test
     runs-on: ${{ matrix.os }}
@@ -101,7 +101,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [ 1.20 ]
+        go: [ '1.20' ]
     name: lint go
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,5 +117,4 @@ jobs:
       - name: "Run golangci"
         uses: golangci/golangci-lint-action@v3  # docs: https://github.com/golangci/golangci-lint-action
         with:
-          version: v1.50
-          args: --go='${{ matrix.go }}'
+          version: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,9 @@ jobs:
     name: lint yaml
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v3
-      - name: Lint YAML
+      - name: "Run YAML linter"
         uses: karancode/yamllint-github-action@master
         with:
           yamllint_file_or_dir: '.github/ci/yamllint.yml'
@@ -30,48 +30,69 @@ jobs:
   go-mod:
     strategy:
       matrix:
-        go: [1.18]
+        go: [ 1.20 ]
     name: check go.mod
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
+      - name: "Setup Go"
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v3
-      - name: Run go mod tidy
+      - name: "Run go mod tidy"
         run: go mod tidy -v
-      - name: Check go.mod
+      - name: "Check go.mod"
         run: |
           git diff --exit-code go.mod
-      - name: Check go.sum
+      - name: "Check go.sum"
         run: |
           git diff --exit-code go.sum
-    
+
+  binapi:
+    strategy:
+      matrix:
+        go: [ 1.20 ]
+    env:
+      VERSION: v0.7.0
+    name: check binapi
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Setup Go"
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: "Checkout"
+        uses: actions/checkout@v3
+      - name: "Generate binapi"
+        run: make gen-binapi-docker
+      - name: "Check go.mod"
+        run: |
+          git diff --exit-code binapi
+
   build-test:
     strategy:
       matrix:
-        go: [1.18]
-        os: [ubuntu-latest]
+        go: [ 1.20 ]
+        os: [ ubuntu-latest ]
     name: build and test
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup Go
+      - name: "Setup Go"
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - name: Setup gotestsum
+      - name: "Setup gotestsum"
         uses: autero1/action-gotestsum@v1.0.0
         with:
-          gotestsum_version: 1.8.2
-      - name: Checkout
+          gotestsum_version: 1.9.0
+      - name: "Checkout"
         uses: actions/checkout@v3
-      - name: Build
+      - name: "Build"
         run: go build -v ./...
-      - name: Test
+      - name: "Test"
         run: gotestsum --format testname --jsonfile test.json -- -race ./...
-      - name: Annotate tests
+      - name: "Annotate tests"
         if: always()
         uses: guyarb/golang-test-annotations@v0.6.0
         with:
@@ -80,20 +101,20 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [1.18]
+        go: [ 1.20 ]
     name: lint go
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     steps:
-      - name: Setup Go
+      - name: "Setup Go"
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v3
-      - name: golangci-lint
+      - name: "Run golangci"
         uses: golangci/golangci-lint-action@v3  # docs: https://github.com/golangci/golangci-lint-action
         with:
           version: v1.50

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,4 +118,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3  # docs: https://github.com/golangci/golangci-lint-action
         with:
           version: v1.50
-          args: --go="${{ matrix.go }}"
+          args: --go='${{ matrix.go }}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request:
+  # Runs at 05:05. Daily.
+  schedule:
+    - cron: '5 5 * * *'
   # Allows running this workflow manually
   workflow_dispatch:
 

--- a/test/build/Dockerfile.integration
+++ b/test/build/Dockerfile.integration
@@ -14,14 +14,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		wget \
  	&& rm -rf /var/lib/apt/lists/*
 
-ARG GOTESTSUM_VERSION=1.8.2
+ARG GOTESTSUM_VERSION=1.9.0
 RUN curl -fsSL https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz -o gotestsum.tar.gz \
     && tar -xf gotestsum.tar.gz gotestsum \
     && mv gotestsum /usr/local/bin/gotestsum \
     && rm gotestsum.tar.gz
 
 # Install Go
-ENV GOLANG_VERSION 1.18.3
+ENV GOLANG_VERSION 1.20
 
 RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \


### PR DESCRIPTION
This PR updates CI workflow:
- Go updated to 1.20
- add CI job to test if generated binapi is up-to-date