### PR TITLE
Trace refactored

### DIFF
--- a/api/trace.go
+++ b/api/trace.go
@@ -18,22 +18,22 @@ import (
 	"time"
 )
 
-// Trace gives access to the API trace tool, capturing outcoming and incoming messages
-// to and from GoVPP.
+// Trace is the GoVPP utility tool capturing processed API messages. The trace is not operational
+// by default.
+// Enable trace for a given connection by calling `NewTrace(connection, size)`
 type Trace interface {
-	// Enable allows to enable or disable API trace for a connection.
-	Enable(enable bool)
-
-	// GetRecords retrieves all messages collected (from all channels if they are used)
-	// since the point the trace was enabled or cleared.
+	// GetRecords returns all API messages from all channels captured since the trace
+	// was initialized or cleared up to the point of the call.
 	GetRecords() []*Record
 
-	// GetRecordsForChannel retrieves messages collected by the given channel since
-	// the point the trace was enabled or cleared.
+	// GetRecordsForChannel returns all API messages recorded by the given channel.
 	GetRecordsForChannel(chId uint16) []*Record
 
 	// Clear erases messages captured so far.
 	Clear()
+
+	// Close the tracer and release associated resources
+	Close()
 }
 
 // Record contains essential information about traced message, its timestamp and whether

--- a/core/channel.go
+++ b/core/channel.go
@@ -224,7 +224,6 @@ func (req *requestCtx) ReceiveReply(msg api.Message) error {
 	} else if lastReplyReceived {
 		return errors.New("multipart reply recieved while a single reply expected")
 	}
-
 	return nil
 }
 

--- a/core/trace.go
+++ b/core/trace.go
@@ -18,51 +18,96 @@ import (
 	"go.fd.io/govpp/api"
 	"sort"
 	"sync"
-	"sync/atomic"
 )
 
-// trace is the API tracer object synchronizing and keeping recoded messages.
-type trace struct {
-	list []*api.Record
-	mux  *sync.Mutex
+// default buffer size
+const bufferSize = 100
 
-	isEnabled int32
+// Trace is the default trace API implementation.
+type Trace struct {
+	*sync.RWMutex
+	wg sync.WaitGroup
+
+	records []*api.Record
+	buffer  chan *api.Record
+	index   int
+
+	closeFunc func()
 }
 
-func (c *trace) Enable(enable bool) {
-	if enable && atomic.CompareAndSwapInt32(&c.isEnabled, 0, 1) {
-		log.Debugf("API trace enabled")
-	} else if atomic.CompareAndSwapInt32(&c.isEnabled, 1, 0) {
-		log.Debugf("API trace disabled")
+// NewTrace initializes the trace object, always bound to a GoVPP connection.
+// The size limits the number of records stored.
+// Initializing a new trace for the same connection replaces the old one and
+// discards all values already collected.
+func NewTrace(c *Connection, size int) (t *Trace) {
+	t = &Trace{
+		RWMutex: &sync.RWMutex{},
+		records: make([]*api.Record, size),
+		buffer:  make(chan *api.Record, bufferSize),
 	}
+	c.trace = t
+	t.closeFunc = func() {
+		c.trace = nil // no more records
+		close(t.buffer)
+	}
+	go func() {
+		for {
+			select {
+			case record, ok := <-t.buffer:
+				if !ok {
+					return
+				}
+				if t.index < len(t.records) {
+					t.RLock()
+					t.records[t.index] = record
+					t.index++
+					t.RUnlock()
+				}
+				t.wg.Done()
+			}
+		}
+	}()
+	return
 }
 
-func (c *trace) GetRecords() (list []*api.Record) {
-	c.mux.Lock()
-	list = append(list, c.list...)
-	c.mux.Unlock()
+func (t *Trace) GetRecords() (list []*api.Record) {
+	// it is supposed to wait until all API messages sent to the
+	// buffer are processed before returning the list
+	t.wg.Wait()
+	t.Lock()
+	list = make([]*api.Record, t.index)
+	copy(list, t.records[:t.index])
+	t.Unlock()
 	sort.Slice(list, func(i, j int) bool {
 		return list[i].Timestamp.Before(list[j].Timestamp)
 	})
 	return list
 }
 
-func (c *trace) GetRecordsForChannel(chId uint16) (list []*api.Record) {
-	c.mux.Lock()
-	for _, entry := range c.list {
-		if entry.ChannelID == chId {
-			list = append(list, entry)
+func (t *Trace) GetRecordsForChannel(chId uint16) (list []*api.Record) {
+	records := t.GetRecords()
+	for _, record := range records {
+		if record.ChannelID == chId {
+			list = append(list, record)
 		}
 	}
-	c.mux.Unlock()
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].Timestamp.Before(list[j].Timestamp)
-	})
 	return list
 }
 
-func (c *trace) Clear() {
-	c.mux.Lock()
-	c.list = make([]*api.Record, 0)
-	c.mux.Unlock()
+func (t *Trace) Clear() {
+	t.Lock()
+	t.records = make([]*api.Record, len(t.records))
+	t.index = 0
+	t.Unlock()
+}
+
+func (t *Trace) Close() {
+	t.closeFunc()
+}
+
+func (t *Trace) record(r *api.Record) {
+	if t != nil {
+		t.wg.Add(1)
+		t.buffer <- r
+	}
 }

--- a/examples/api-trace/README.md
+++ b/examples/api-trace/README.md
@@ -1,17 +1,30 @@
 # API trace example
 
-The example demonstrates how to use GoVPP API trace functionality. Connection object `core.Connection` contains
-API tracer able to record API messages sent to and from VPP.
+The example demonstrates how to use the GoVPP API trace functionality. The trace is bound to a connection.
+The `core.Connection` includes the API trace object capable of recording API messages processed during the VPP API
+message exchange. Traced messages are called `records`.
 
-Access to the tracer is done via `Trace()`. It allows accessing several methods to manage collected entries:
-* `Enable(<bool>)` either enables or disables the trace. Note that the trace is disabled by default and messages are not recorded while so.
-* `GetRecords() []*api.Record` provide messages collected since the plugin was enabled or cleared.
-* `GetRecordsForChannel(<channelID>) []*api.Record` provide messages collected on the given channel since the plugin was enabled or cleared.
-* `Clear()` removes recorded messages.
+Each record contains information about the API message, its direction, time, and the channel ID.
 
-A record is represented by `Record` type. It contains information about the message, its direction, time and channel ID. Following fields are available:
-* `Message api.Message` returns recorded entry as GoVPP Message.
-* `Timestamp time.Time` is the message timestamp.
-* `IsReceived bool` is true if the message is a reply or details message, false otherwise.
-* `ChannelID uint16` is the ID of channel processing the traced message. 
+The trace is disabled by default. In order to enable it, call `NewTrace`:
 
+```go
+c, err := govpp.Connect(*sockAddr)
+if err != nil {
+// handler error
+}
+size := 10
+trace := core.NewTrace(c, size)
+defer trace.Close()
+```
+
+The code above initializes the new tracer which records a certain number of messages defined by the `size`.
+
+The following methods are available to call on the trace:
+
+* `GetRecords() []*Record` returns all records beginning with the initialization of the trace till the point of the
+  method call. The size also restricts the maximum number of records. All records received after the tracer is full are
+  discarded.
+* `GetRecordsForChannel(chId uint16) []*Record` works the same as the method above, but filters messages per channel.
+* `Clear()` resets the tracer and allows to reuse it with (the size remains the same).
+* `Close()` closes the tracer.

--- a/examples/api-trace/api-trace.go
+++ b/examples/api-trace/api-trace.go
@@ -48,23 +48,24 @@ func main() {
 	}
 	defer conn.Disconnect()
 
-	singleChannel(conn)
-	multiChannel(conn)
-	stream(conn)
+	fmt.Printf("=> Enabling API trace...\n")
+	trace := core.NewTrace(conn, 50)
 
+	singleChannel(conn, trace)
+	multiChannel(conn, trace)
+	stream(conn, trace)
+
+	trace.Close()
 	fmt.Printf("Api-trace tool example finished\n\n")
 }
 
-func singleChannel(conn *core.Connection) {
+func singleChannel(conn *core.Connection, trace api.Trace) {
 	// create new channel and perform simple compatibility check
 	ch, err := conn.NewAPIChannel()
 	if err != nil {
 		log.Fatalln("ERROR: creating channel failed:", err)
 	}
 	defer ch.Close()
-
-	fmt.Printf("=> Example 1\n\nEnabling API trace...\n")
-	conn.Trace().Enable(true)
 
 	if err := ch.CheckCompatiblity(append(vpe.AllMessages(), interfaces.AllMessages()...)...); err != nil {
 		log.Fatal(err)
@@ -79,18 +80,18 @@ func singleChannel(conn *core.Connection) {
 	deleteLoopback(ch, idx)
 	fmt.Println()
 
-	fmt.Printf("API trace (api calls: %d):\n", len(conn.Trace().GetRecords()))
+	fmt.Printf("API trace (api calls: %d):\n", len(trace.GetRecords()))
 	fmt.Printf("--------------------\n")
-	for _, item := range conn.Trace().GetRecords() {
+	for _, item := range trace.GetRecords() {
 		printTrace(item)
 	}
 	fmt.Printf("--------------------\n")
 
 	fmt.Printf("Clearing API trace...\n\n")
-	conn.Trace().Clear()
+	trace.Clear()
 }
 
-func multiChannel(conn *core.Connection) {
+func multiChannel(conn *core.Connection, trace api.Trace) {
 	ch1, err := conn.NewAPIChannel()
 	if err != nil {
 		log.Fatalln("ERROR: creating channel failed:", err)
@@ -123,30 +124,30 @@ func multiChannel(conn *core.Connection) {
 		log.Fatalln("ERROR: incorrect type of channel 2:", err)
 	}
 
-	fmt.Printf("API trace for channel 1 (api calls: %d):\n", len(conn.Trace().GetRecordsForChannel(chan1.GetID())))
+	fmt.Printf("API trace for channel 1 (api calls: %d):\n", len(trace.GetRecordsForChannel(chan1.GetID())))
 	fmt.Printf("--------------------\n")
-	for _, item := range conn.Trace().GetRecordsForChannel(chan1.GetID()) {
+	for _, item := range trace.GetRecordsForChannel(chan1.GetID()) {
 		printTrace(item)
 	}
 	fmt.Printf("--------------------\n")
-	fmt.Printf("API trace for channel 2 (api calls: %d):\n", len(conn.Trace().GetRecordsForChannel(chan2.GetID())))
+	fmt.Printf("API trace for channel 2 (api calls: %d):\n", len(trace.GetRecordsForChannel(chan2.GetID())))
 	fmt.Printf("--------------------\n")
-	for _, item := range conn.Trace().GetRecordsForChannel(chan2.GetID()) {
+	for _, item := range trace.GetRecordsForChannel(chan2.GetID()) {
 		printTrace(item)
 	}
 	fmt.Printf("--------------------\n")
-	fmt.Printf("cumulative API trace (api calls: %d):\n", len(conn.Trace().GetRecords()))
+	fmt.Printf("cumulative API trace (api calls: %d):\n", len(trace.GetRecords()))
 	fmt.Printf("--------------------\n")
-	for _, item := range conn.Trace().GetRecords() {
+	for _, item := range trace.GetRecords() {
 		printTrace(item)
 	}
 	fmt.Printf("--------------------\n")
 
 	fmt.Printf("Clearing API trace...\n\n")
-	conn.Trace().Clear()
+	trace.Clear()
 }
 
-func stream(conn *core.Connection) {
+func stream(conn *core.Connection, trace api.Trace) {
 	// create new channel and perform simple compatibility check
 	s, err := conn.NewStream(context.Background())
 	if err != nil {
@@ -167,15 +168,15 @@ func stream(conn *core.Connection) {
 	invokeDeleteLoopback(conn, idx)
 	fmt.Println()
 
-	fmt.Printf("stream API trace (api calls: %d):\n", len(conn.Trace().GetRecords()))
+	fmt.Printf("stream API trace (api calls: %d):\n", len(trace.GetRecords()))
 	fmt.Printf("--------------------\n")
-	for _, item := range conn.Trace().GetRecords() {
+	for _, item := range trace.GetRecords() {
 		printTrace(item)
 	}
 	fmt.Printf("--------------------\n")
 
 	fmt.Printf("Clearing API trace...\n\n")
-	conn.Trace().GetRecords()
+	trace.GetRecords()
 }
 
 func retrieveVersion(ch api.Channel) {


### PR DESCRIPTION
The way how the API trace is initialized was changed - the trace is no longer initialized and is flagged as disabled by the connection. Instead, the user creates a new trace object and bounds it to a connection.

API changes:
* trace is no longer available from the connection object via the `Trace()` method.
* `Enable(bool)` was removed from the `Trace` API. Instead, the method `NewTrace(connection, size)` is added.
* Added method `Close()` to release resources used by the tracer. 

Workflow changes:
* trace is done before `vppClient.SendMsg` so the failed message is also traced
* instead of appending to a list, the connection sends records to the buffered channel
* `GetRecords` waits until all incoming messages are processed before returning the list

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>