### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/test/build/Dockerfile.integration
+++ b/test/build/Dockerfile.integration
@@ -1,17 +1,17 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https \
-		ca-certificates \
-		curl \
-		git \
-		gnupg \
-		iproute2 \
-		iputils-ping \
-		make \
-		nano \
-		sudo \
-		wget \
+        apt-transport-https=2.0.* \
+        ca-certificates=20211016ubuntu0.20.* \
+        curl=7.68.* \
+        git=1:2.25.* \
+        gnupg=2.2.* \
+        iproute2=5.5.* \
+        iputils-ping=3:20190709-3 \
+        make=4.2.* \
+        nano=4.8-* \
+        sudo=1.8.* \
+        wget=1.20.* \
  	&& rm -rf /var/lib/apt/lists/*
 
 ARG GOTESTSUM_VERSION=1.9.0
@@ -46,8 +46,8 @@ RUN set -eux; \
 	apt-get update; \
 	curl -fsSL https://packagecloud.io/install/repositories/fdio/${VPP_REPO}/script.deb.sh | bash; \
 	apt-get update && apt-get install -V -y \
-		vpp \
-		vpp-plugin-core \
+        vpp \
+        vpp-plugin-core \
 	; \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "test/build/Dockerfile.integration" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved from the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance