### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot configuration
+#
+# See docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+---
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "FDio/govpp-commiters"
+    groups:
+      github-deps:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "FDio/govpp-commiters"
+    groups:
+      go-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
This change enables automatic dependency updates by Dependabot. This includes dependencies of GitHub Actions (used in workflows) and Go modules (`go.mod`).