### PR TITLE
Update run_integration.sh

### DIFF
--- a/test/run_integration.sh
+++ b/test/run_integration.sh
@@ -42,6 +42,11 @@ docker build --tag "${imgtag}" \
 
 vppver=$(docker run --rm -i "${imgtag}" dpkg-query -f '${Version}' -W vpp)
 
+if [ -n "${GITHUB_STEP_SUMMARY}" ]; then
+    echo "**VPP version**: \`${vppver}\`" >> $GITHUB_STEP_SUMMARY
+    echo "" >> $GITHUB_STEP_SUMMARY
+fi
+
 echo "=========================================================================="
 echo " GOVPP INTEGRATION TEST - $(date) "
 echo "=========================================================================="


### PR DESCRIPTION
This change will add info about VPP version to job summary of CI tests.

Check this action run to see how it looks: https://github.com/FDio/govpp/actions/runs/5712980078?pr=154
