### PR TITLE
Fix broken links in README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,11 +2,11 @@
 
 Here is a list of code examples demonstrating various GoVPP features:
 
-- [api-trace](examples/api-trace) - trace sent/received messages
-- [binapi-types](examples/binapi-types) - using common types from generated code
-- [multi-vpp](examples/multi-vpp) - connect to multiple VPP instances
-- [perf-bench](examples/perf-bench) - very basic performance test for measuring throughput
-- [rpc-service](examples/rpc-service) - effortless way to call VPP API via RPC client
-- [simple-client](examples/simple-client) - send and receive VPP API messages using GoVPP API directly
-- [stats-client](examples/stats-client) - client for retrieving VPP stats data
-- [stream-client](examples/stream-client) - using new stream API to call VPP API
+- [api-trace](api-trace) - trace sent/received messages
+- [binapi-types](binapi-types) - using common types from generated code
+- [multi-vpp](multi-vpp) - connect to multiple VPP instances
+- [perf-bench](perf-bench) - very basic performance test for measuring throughput
+- [rpc-service](rpc-service) - effortless way to call VPP API via RPC client
+- [simple-client](simple-client) - send and receive VPP API messages using GoVPP API directly
+- [stats-client](stats-client) - client for retrieving VPP stats data
+- [stream-client](stream-client) - using new stream API to call VPP API


### PR DESCRIPTION
Found a few broken links while reading example docs. This pull request fixes them.