### PR TITLE
fix wasted control_ping_id caching

### DIFF
--- a/core/connection.go
+++ b/core/connection.go
@@ -548,10 +548,10 @@ func (c *Connection) retrieveMessageIDs() (err error) {
 			n++
 			nn++
 
-			if c.pingReqID == 0 && msg.GetMessageName() == c.msgControlPing.GetMessageName() {
+			if msg.GetMessageName() == c.msgControlPing.GetMessageName() {
 				c.pingReqID = msgID
 				c.msgControlPing = reflect.New(reflect.TypeOf(msg).Elem()).Interface().(api.Message)
-			} else if c.pingReplyID == 0 && msg.GetMessageName() == c.msgControlPingReply.GetMessageName() {
+			} else if msg.GetMessageName() == c.msgControlPingReply.GetMessageName() {
 				c.pingReplyID = msgID
 				c.msgControlPingReply = reflect.New(reflect.TypeOf(msg).Elem()).Interface().(api.Message)
 			}


### PR DESCRIPTION
When you update asan-dbg vpp from one version to another with different id's for "control_ping" api-call, you get a coredump in vpp because these counters haven't been updated during table reset. It happens here: https://github.com/FDio/govpp/blob/master/core/request_handler.go#L160 