### PR TITLE
Gomemif improvemets

### DIFF
--- a/extras/gomemif/memif/interface.go
+++ b/extras/gomemif/memif/interface.go
@@ -525,7 +525,7 @@ func (i *Interface) connect() (err error) {
 		q.lastTail = 0
 	}
 
-	for _, q := range i.rxQueues {
+	for qid, q := range i.rxQueues {
 		q.updateRing()
 
 		if q.ring.getCookie() != cookie {
@@ -534,6 +534,11 @@ func (i *Interface) connect() (err error) {
 
 		q.lastHead = 0
 		q.lastTail = 0
+
+		if i.args.InterruptFunc != nil {
+			interruptFd, _ := q.GetEventFd()
+			i.socket.intfQueueEventMap[interruptFd] = memifIntfQueue{i, uint16(qid)}
+		}
 	}
 
 	return i.args.ConnectedFunc(i)

--- a/extras/gomemif/memif/packet_reader.go
+++ b/extras/gomemif/memif/packet_reader.go
@@ -107,6 +107,7 @@ func (q *Queue) Rx_burst(pkt []MemifPacketBuffer) (uint16, error) {
 	var length uint32
 	var offset uint32
 	var nSlots uint16
+	var readQueueInterrupt bool = true
 	var desc descBuf = newDescBuf()
 
 	if q.i.args.IsMaster {
@@ -126,6 +127,7 @@ func (q *Queue) Rx_burst(pkt []MemifPacketBuffer) (uint16, error) {
 
 	if nSlots > uint16(len(pkt)) {
 		nSlots = uint16(len(pkt))
+		readQueueInterrupt = false
 	}
 
 	rx := 0
@@ -148,8 +150,10 @@ func (q *Queue) Rx_burst(pkt []MemifPacketBuffer) (uint16, error) {
 
 	}
 
-	b := make([]byte, 8)
-	syscall.Read(int(q.interruptFd), b)
+	if readQueueInterrupt {
+		b := make([]byte, 8)
+		syscall.Read(int(q.interruptFd), b)
+	}
 
 	return uint16(rx), nil
 }

--- a/extras/gomemif/memif/packet_reader.go
+++ b/extras/gomemif/memif/packet_reader.go
@@ -124,6 +124,10 @@ func (q *Queue) Rx_burst(pkt []MemifPacketBuffer) (uint16, error) {
 		return 0, nil
 	}
 
+	if nSlots > uint16(len(pkt)) {
+		nSlots = uint16(len(pkt))
+	}
+
 	rx := 0
 	for nSlots > 0 {
 		// copy descriptor from shm


### PR DESCRIPTION
Packet reader function does not consider the length of
the packet array to accommodate the number of receiving
packets. It results in crash, if receiving packets are
more than packet array length. This issue has been fixed.

Previously, nested iterations over interfaces and queues
were used to handle receive interrupts. It has been replaced
that approach with a lookup-based solution.

Previously, packets could starve in the receive queue
if `rx_burst` read fewer packets than were enqueued.
The fix ensures the queue remains interrupted,
allowing the event handler to continue processing
until all packets in the receive queue have been read.


fixes #85 