### PR TITLE
Docker image and release improvements

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,10 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
+      - name: "Print environment"
+        run: |
+          env | sort
+
       - name: "Release Version"
         if: success() && startsWith(github.ref, 'refs/tags/v')
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ builds:
       - -X go.fd.io/govpp/version.commit={{.FullCommit}}
       - -X go.fd.io/govpp/version.branch={{.Branch}}
       - -X go.fd.io/govpp/version.buildStamp={{.Timestamp}}
+      - -X go.fd.io/govpp/version.buildUser={{if index .Env "USER"}}{{.Env.USER}}{{else}}goreleaser{{end}}
+      - -X go.fd.io/govpp/version.buildHost={{if index .Env "HOSTNAME"}}{{.Env.HOSTNAME}}{{else}}goreleaser{{end}}
 
 archives:
   - id: govpp-archive
@@ -53,10 +55,11 @@ changelog:
 
 dockers:
   - dockerfile: Dockerfile.govpp
+    skip_push: auto
     image_templates:
       - "ghcr.io/fdio/govpp:{{ .Tag }}"
-      - "ghcr.io/fdio/govpp:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/fdio/govpp:latest"
+      - "{{if not .Prerelease}}ghcr.io/fdio/govpp:v{{ .Major }}.{{ .Minor }}{{end}}"
+      - "{{if not .Prerelease}}ghcr.io/fdio/govpp:latest{{end}}"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/Dockerfile.govpp
+++ b/Dockerfile.govpp
@@ -1,3 +1,13 @@
-FROM scratch
+FROM alpine:3.20
+
+RUN set -eux; \
+    apk add --no-cache \
+        bash \
+        git \
+        make \
+        python3 \
+        py3-ply
+
 COPY govpp /
+
 ENTRYPOINT ["/govpp"]

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ install-goreleaser: ## Install goreleaser
 	@go install github.com/goreleaser/goreleaser/v2@latest
 
 .PHONY: release-snapshot
-release-snapshot:
+release-snapshot: ## Release snapshot
 	@goreleaser release --clean --snapshot
 
 .PHONY: generate

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,15 @@ install-proxy: ## Install vpp-proxy
 	@echo "# installing vpp-proxy ${VERSION}"
 	@go install ${GO_BUILD_ARGS} ./cmd/vpp-proxy
 
+.PHONY: install-goreleaser
+install-goreleaser: ## Install goreleaser
+	@echo "# installing goreleaser"
+	@go install github.com/goreleaser/goreleaser/v2@latest
+
+.PHONY: release-snapshot
+release-snapshot:
+	@goreleaser release --clean --snapshot
+
 .PHONY: generate
 generate: generate-binapi ## Generate all
 


### PR DESCRIPTION
This PR fixes the official Docker image to include some packages required by some GoVPP CLI commands. 

Changes:
- add missing packages in `Dockerfile.govpp`
- add make target `release-snapshot` for releasing local snapshot using goreleaser
- set `biulduser` and `buildHost` in the release workflow
- for prerelease versions, skip pushing image tags `:v<MAJOR>.<MINOR>` and `:latest`