### PR TITLE
Fix golangci.yml for 1.64.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,11 @@
 ---
 run:
   timeout: 5m
-  skip-dirs:
+
+issues:
+  exclude-dirs:
     - adapter/mock
-  skip-files:
+  exclude-files:
     - ".*\\.ba.\\.go$"
 
 linters:


### PR DESCRIPTION
This patch fixes the golangci.yml config file for golangci-lint as this breaks the GH actions lint step.


Change-Id: I6e8a6a8d2dd989dc80c100add801f39c3d3351ae