### PR TITLE
Unify version

### DIFF
--- a/cmd/govpp/cmd.go
+++ b/cmd/govpp/cmd.go
@@ -38,7 +38,7 @@ func newRootCmd(cli Cli) *cobra.Command {
 		Short: "GoVPP CLI tool",
 		Long: color.Sprintf(logo, version.Short(), version.BuiltBy(), version.BuildTime()) + "\n" +
 			"GoVPP is an universal CLI tool for any VPP-related development.",
-		Version: version.String(),
+		Version: version.Version(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			InitOptions(cli, &glob)
 			return nil

--- a/govpp.go
+++ b/govpp.go
@@ -48,5 +48,5 @@ var NewVppAdapter = func(target string) adapter.VppAPI {
 
 // Version returns version of GoVPP.
 func Version() string {
-	return version.String()
+	return version.Version()
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -23,22 +23,6 @@ import (
 	"time"
 )
 
-const (
-	Major      = 0
-	Minor      = 12
-	Patch      = 0
-	PreRelease = "dev"
-)
-
-// String formats the version string using semver format.
-func String() string {
-	v := fmt.Sprintf("v%d.%d.%d", Major, Minor, Patch)
-	if PreRelease != "" {
-		v += "-" + PreRelease
-	}
-	return v
-}
-
 // Following variables should normally be updated via `-ldflags "-X ..."`.
 // However, the version string is hard-coded to ensure it is always included
 // even with bare go build/install.
@@ -80,6 +64,7 @@ func binaryModTime() (time.Time, error) {
 	return fileInfo.ModTime(), nil
 }
 
+// Version return semver string.
 func Version() string {
 	return version
 }


### PR DESCRIPTION
This pull request includes changes to the versioning system in the GoVPP CLI tool. The most important changes involve replacing the `String` method with a new `Version` method for better version representation and updating the related code accordingly.

Changes to versioning system:

* [`cmd/govpp/cmd.go`](diffhunk://#diff-7b44ab19d108cec72a003ff4548f193c1700332abde432375b720d5b47404dd3L41-R41): Updated the `Version` field in the `newRootCmd` function to use `version.Version()` instead of `version.String()`.
* [`govpp.go`](diffhunk://#diff-886ca32e4f7cdfeb016a096cdd1867aaff98df7bcc93f92088adf8f907e26713L51-R51): Replaced the `String` method with the `Version` method in the `Version` function.
* [`internal/version/version.go`](diffhunk://#diff-8aa632a6f4ad2a3a7fef52661816aa3977f23c0673ef29633c01116fee6745c6L26-L41): Removed the `String` method and related constants (`Major`, `Minor`, `Patch`, `PreRelease`) and added a new `Version` method to return the semver string. [[1]](diffhunk://#diff-8aa632a6f4ad2a3a7fef52661816aa3977f23c0673ef29633c01116fee6745c6L26-L41) [[2]](diffhunk://#diff-8aa632a6f4ad2a3a7fef52661816aa3977f23c0673ef29633c01116fee6745c6R67)