### PR TITLE
Change Channel ID not known log message level

### DIFF
--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -276,7 +276,11 @@ func (c *Connection) msgCallback(msgID uint16, data []byte) {
 				l.Debugf("Unable to decode message: %v", err)
 			}
 		}
-		l.Errorf("Channel ID not known, ignoring the message: %T %+v", msg, msg)
+		// This can happen when a stream was closed explicitly before the last message received.
+		// It's expected and not an error.
+		if log.Level >= logrus.DebugLevel {
+			l.Debugf("Channel ID not known, ignoring the message: %T %+v", msg, msg)
+		}
 		return
 	}
 


### PR DESCRIPTION
We're using GoVPP and have a lot of cases dumping from VPP using streams. Sometimes we need to find only one single item and close stream after that without reading it till the end. It leads to tonns of errors in logs like: Channel ID not known, ignoring the message: *memclnt.ControlPingReply

So I would like to change "Channel ID not known" log message level, as it looks like expected behaviour and not an error.
