### PR TITLE
gen Reset() by default value

### DIFF
--- a/binapigen/types.go
+++ b/binapigen/types.go
@@ -78,7 +78,7 @@ var BaseTypesGo = map[string]string{
 
 func fieldActualType(field *Field) (actual string) {
 	switch {
-	case field.TypeAlias != nil:
+	case field.TypeAlias != nil && field.TypeAlias.Length == 0:
 		actual = field.TypeAlias.Type
 	case field.TypeEnum != nil:
 		actual = field.TypeEnum.Type


### PR DESCRIPTION
govpp does not utilise binapi's prompts for default member values.
```go

// Initialize a new bond interface with the given paramters
//   - id - if non-~0, specifies a custom interface ID
//   - use_custom_mac - if set, mac_address is valid
//   - mac_address - mac addr to assign to the interface if use_custom_mac is set
//   - mode - mode, required (1=round-robin, 2=active-backup, 3=xor, 4=broadcast, 5=lacp)
//   - lb - load balance, optional (0=l2, 1=l34, 2=l23) valid for xor and lacp modes. Otherwise ignored
//   - numa_only - if numa_only is set, pkts will be transmitted by LAG members on local numa node only if have at least one, otherwise it works as usual.
//
// BondCreate defines message 'bond_create'.
// Deprecated: the message will be removed in the future versions
type BondCreate struct {
	ID           uint32                    `binapi:"u32,name=id,default=4294967295" json:"id,omitempty"`
	UseCustomMac bool                      `binapi:"bool,name=use_custom_mac" json:"use_custom_mac,omitempty"`
	MacAddress   ethernet_types.MacAddress `binapi:"mac_address,name=mac_address" json:"mac_address,omitempty"`
	Mode         BondMode                  `binapi:"bond_mode,name=mode" json:"mode,omitempty"`
	Lb           BondLbAlgo                `binapi:"bond_lb_algo,name=lb" json:"lb,omitempty"`
	NumaOnly     bool                      `binapi:"bool,name=numa_only" json:"numa_only,omitempty"`
}

func (m *BondCreate) Reset()               { *m = BondCreate{ID: 4294967295} }
```