### PR TITLE
Closes #320 issue with Unsubscribe with the latest element in msgSubscriptions.

### DIFF
--- a/core/connection.go
+++ b/core/connection.go
@@ -234,7 +234,7 @@ func AsyncConnect(binapi adapter.VppAPI, attempts int, interval time.Duration) (
 	atomic.StoreUint32(&conn.backgroundLoopActive, 1)
 
 	// asynchronously attempt to connect to VPP
-	go conn.backgroudConnectionLoop()
+	go conn.backgroundConnectionLoop()
 
 	return conn, conn.connChan, nil
 }
@@ -350,7 +350,7 @@ func (c *Connection) releaseAPIChannel(ch *Channel) {
 }
 
 // runs connectionLoop and healthCheckLoop until they fail
-func (c *Connection) backgroudConnectionLoop() {
+func (c *Connection) backgroundConnectionLoop() {
 	defer close(c.healthCheckExited)
 
 	for {

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"go.fd.io/govpp/api"
+	interfaces "go.fd.io/govpp/binapi/interface"
+)
+
+func TestNotificationMessageAfterUnsubscribe(t *testing.T) {
+	ctx := setupTest(t)
+	defer ctx.teardownTest()
+
+	notifMsg := &interfaces.SwInterfaceEvent{}
+	msgID, err := ctx.conn.GetMessageID(notifMsg)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	// Before subscribing, isNotificationMessage should return false
+	isNotif := ctx.conn.isNotificationMessage(msgID)
+	Expect(isNotif).Should(BeFalse())
+
+	// Subscribe to the notification
+	notifChan := make(chan api.Message, 10)
+	sub, err := ctx.ch.SubscribeNotification(notifChan, notifMsg)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(sub).ShouldNot(BeNil())
+
+	// After subscribing, isNotificationMessage should return true
+	isNotif = ctx.conn.isNotificationMessage(msgID)
+	Expect(isNotif).Should(BeTrue())
+
+	// Unsubscribe from the notification
+	err = sub.Unsubscribe()
+	Expect(err).ShouldNot(HaveOccurred())
+
+	// After unsubscribing the last (and only) subscription, isNotificationMessage should return false
+	isNotif = ctx.conn.isNotificationMessage(msgID)
+	Expect(isNotif).Should(BeFalse(), "isNotificationMessage should return false after unsubscribing from the last subscription")
+}


### PR DESCRIPTION
Please check #320 issue for more details.

More details on PR:
- fixed the Unsubscribe logic to remove msgSubscriptions from the subscriptions map when the last element in the slice is removed.
- since the order of elements doesn’t matter here, I made a small performance improvement to the removal logic by swapping the element with the last one and truncating the slice.
- fixed a small typo in backgroundConnectionLoop.
- added a test for Unsubscribe, including a check for whether the message is a notification.