### PR TITLE
copy stat entry name off shared memory region

### DIFF
--- a/adapter/statsclient/statseg_v1.go
+++ b/adapter/statsclient/statseg_v1.go
@@ -15,6 +15,7 @@
 package statsclient
 
 import (
+	"bytes"
 	"sync/atomic"
 	"unsafe"
 
@@ -76,7 +77,10 @@ func (ss *statSegmentV1) GetStatDirOnIndex(v dirVector, index uint32) (dirSegmen
 	var name []byte
 	for n := 0; n < len(dir.name); n++ {
 		if dir.name[n] == 0 {
-			name = dir.name[:n]
+			// Copy the name off the statseg shared memory region before returning.
+			// The caller must not hold a reference into the mmap'd region after
+			// DumpStats returns, because VPP may unmap the segment at any time.
+			name = bytes.Clone(dir.name[:n])
 			break
 		}
 	}

--- a/adapter/statsclient/statseg_v2.go
+++ b/adapter/statsclient/statseg_v2.go
@@ -78,7 +78,10 @@ func (ss *statSegmentV2) GetStatDirOnIndex(v dirVector, index uint32) (dirSegmen
 	var name []byte
 	for n := 0; n < len(dir.name); n++ {
 		if dir.name[n] == 0 {
-			name = dir.name[:n]
+			// Copy the name off the statseg shared memory region before returning.
+			// The caller must not hold a reference into the mmap'd region after
+			// DumpStats returns, because VPP may unmap the segment at any time.
+			name = bytes.Clone(dir.name[:n])
 			break
 		}
 	}


### PR DESCRIPTION
GetStatDirOnIndex returned a dirName slice backed directly by the mmap'd statseg region. If VPP unmaps the segment (e.g. on shutdown) after DumpStats returns but before the caller reads the name, any access causes a hardware fault. 

Clone to ensure the returned slice is heap-allocated and safe to use after disconnect.