### PR TITLE
adapter/statsclient: read ring buffers incrementally

### DIFF
--- a/adapter/stats_api.go
+++ b/adapter/stats_api.go
@@ -193,6 +193,9 @@ type RingBufferStat struct {
 // serving a window means carrying a read cursor between refreshes. That cursor
 // is consumer-side state - the segment itself is mapped read-only - and a mock
 // or a v1 segment has nowhere to keep one. Callers type-assert for it.
+//
+// core.StatsConnection holds its StatsAPI unexported and offers no accessor, so
+// this is reached through a *statsclient.StatsClient the caller owns.
 type RingBufferAPI interface {
 	// PrepareRingBuffer resolves one ring-buffer stat by name and returns a
 	// StatDir holding an incremental reader for it, to be refreshed with

--- a/adapter/stats_api.go
+++ b/adapter/stats_api.go
@@ -188,6 +188,101 @@ type RingBufferStat struct {
 	Data    [][]byte // per-thread raw ring data
 }
 
+// RingBufferAPI is implemented by adapters that can read a ring-buffer stat
+// incrementally, and is separate from StatsAPI because not every adapter can:
+// serving a window means carrying a read cursor between refreshes. That cursor
+// is consumer-side state - the segment itself is mapped read-only - and a mock
+// or a v1 segment has nowhere to keep one. Callers type-assert for it.
+type RingBufferAPI interface {
+	// PrepareRingBuffer resolves one ring-buffer stat by name and returns a
+	// StatDir holding an incremental reader for it, to be refreshed with
+	// UpdateDir. maxEntries bounds entries delivered per thread per refresh, zero
+	// meaning the ring size; skipBacklog starts at the producer's head rather
+	// than at the oldest entry the ring still holds.
+	PrepareRingBuffer(name string, maxEntries uint32, skipBacklog bool) (*StatDir, error)
+}
+
+// RingBufferWindow is the run of entries one producer thread appended since a
+// consumer last read it.
+type RingBufferWindow struct {
+	// Entries holds Count entries of RingBufferConfig.EntrySize bytes each,
+	// oldest first and already unwrapped, so a consumer indexes it without
+	// knowing where the ring's seam fell.
+	//
+	// It aliases a buffer the stat owns and reuses, so it is only valid until
+	// the next refresh. Copy anything that must outlive that.
+	//
+	// The slice always starts at the buffer's origin and is capped to the entries
+	// this refresh delivered, so cap(Entries) is the room a refresh has to fill
+	// and there is no second buffer field to keep in step with it.
+	Entries []byte
+	Count   uint32
+
+	// FirstSeq is the producer sequence of Entries[0], and NextSeq the sequence
+	// the following read will start from. Both are absolute counts of entries
+	// this thread has ever written, so they stay meaningful across wraps.
+	FirstSeq uint64
+	NextSeq  uint64
+
+	// Lost counts entries the producer overwrote before this read reached them:
+	// data that is gone. Pending counts entries still in the ring that this read
+	// did not return because MaxEntries capped it: data that the next read will
+	// deliver.
+	//
+	// They are separate because they call for opposite responses. Pending means
+	// read again immediately; Lost means the reader is not keeping up and the
+	// gap is unrecoverable. A single "missed" figure would conflate a reader
+	// that is behind with one that is merely rate-limited.
+	Lost    uint64
+	Pending uint64
+}
+
+// RingBufferWindowStat reads a ring buffer incrementally: every refresh copies
+// only what the producers appended since the previous one, into buffers the stat
+// already owns.
+//
+// This is the difference between a cost proportional to entries produced and one
+// proportional to ring size. RingBufferStat copies the whole ring, for every
+// thread, into a fresh allocation on every read - so a ring sized for burst
+// headroom rather than for poll latency becomes unreadable long before it
+// becomes useful. A 16M-entry ring of 128-byte records is 2 GiB per thread per
+// read as a RingBufferStat, and the entries actually produced as this.
+//
+// Put one in a prepared StatDir entry's Data and refresh it with
+// StatsClient.UpdateDir, or let StatsClient.PrepareRingBuffer build both.
+// CopyEntryData never produces one: windowing needs a read cursor, and only the
+// consumer has it.
+//
+// The zero value is valid and self-initialising. The first refresh reads the
+// geometry, allocates the per-thread buffers, and positions the cursor - at the
+// oldest entry the ring still holds, or at the producer's head if SkipBacklog is
+// set - and returns no entries. SkipBacklog only decides where that first
+// refresh starts and is ignored afterwards; MaxEntries is honoured on every
+// refresh.
+type RingBufferWindowStat struct {
+	// MaxEntries bounds how many entries one refresh delivers per thread, and so
+	// bounds both the buffer this stat allocates and the work one refresh does.
+	// Zero means the ring size, which is the largest window that can ever be
+	// available. A consumer draining a fast producer wants this small enough to
+	// bound a single read and to loop while Pending is non-zero.
+	//
+	// It is read on every refresh, so raising or lowering it between refreshes
+	// takes effect on the next one; the buffers grow to match and are not shrunk.
+	MaxEntries uint32
+
+	// SkipBacklog starts the first read at the producer's head rather than at the
+	// oldest entry still in the ring, so a consumer that wants only what happens
+	// from now on does not first have to read and discard a ring of history.
+	SkipBacklog bool
+
+	Config  RingBufferConfig
+	Threads []RingBufferThreadMeta
+	Schema  []byte
+
+	// Windows holds one window per producer thread, in thread order.
+	Windows []RingBufferWindow
+}
+
 func (ScalarStat) isStat()          {}
 func (ErrorStat) isStat()           {}
 func (SimpleCounterStat) isStat()   {}
@@ -197,6 +292,9 @@ func (EmptyStat) isStat()           {}
 func (GaugeStat) isStat()           {}
 func (HistogramLog2Stat) isStat()   {}
 func (RingBufferStat) isStat()      {}
+
+// Pointer receiver: refreshed in place, so a value must not satisfy Stat.
+func (*RingBufferWindowStat) isStat() {}
 
 func (s ScalarStat) IsZero() bool {
 	return s == 0
@@ -350,6 +448,25 @@ func (s RingBufferStat) IsZero() bool {
 
 func (s RingBufferStat) Type() StatType {
 	return RingBuffer
+}
+
+func (s *RingBufferWindowStat) IsZero() bool {
+	return s.Config.NThreads == 0 || s.Config.EntrySize == 0
+}
+
+func (s *RingBufferWindowStat) Type() StatType {
+	return RingBuffer
+}
+
+func (s *RingBufferWindowStat) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n  config: entry_size=%d, ring_size=%d, threads=%d, schema_version=%d, schema_size=%d",
+		s.Config.EntrySize, s.Config.RingSize, s.Config.NThreads, s.Config.SchemaVersion, s.Config.SchemaSize)
+	for i, w := range s.Windows {
+		fmt.Fprintf(&b, "\n  thread[%d]: entries=%d first_seq=%d next_seq=%d lost=%d pending=%d",
+			i, w.Count, w.FirstSeq, w.NextSeq, w.Lost, w.Pending)
+	}
+	return b.String()
 }
 
 func (s RingBufferStat) String() string {

--- a/adapter/statsclient/statsclient.go
+++ b/adapter/statsclient/statsclient.go
@@ -788,6 +788,11 @@ var _ adapter.RingBufferAPI = (*StatsClient)(nil)
 // reports Pending. skipBacklog starts at the producer's head rather than at the
 // oldest entry still in the ring.
 //
+// Passing zero therefore makes the first refresh allocate the whole ring per
+// thread - RingSize*EntrySize, 1 MiB on an 8192x128 ring - once. The per-read
+// saving stands either way, but a bound is what keeps the allocation off the
+// ring's size too.
+//
 // name is matched exactly, not as a pattern: this returns one entry or an error,
 // because a caller reading a specific producer's records has nothing sensible to
 // do with a second ring that happened to match.

--- a/adapter/statsclient/statsclient.go
+++ b/adapter/statsclient/statsclient.go
@@ -769,3 +769,77 @@ func symlinkItem(full adapter.Stat, item uint32, dst *adapter.Stat) bool {
 	}
 	return false
 }
+
+var _ adapter.RingBufferAPI = (*StatsClient)(nil)
+
+// PrepareRingBuffer resolves one ring-buffer stat by name and returns a StatDir
+// holding an incremental reader for it, to be refreshed with UpdateDir.
+//
+// It exists because PrepareDir cannot express this: PrepareDir populates every
+// entry it prepares by way of CopyEntryData, which for a ring buffer copies the
+// whole ring. On a ring sized for burst headroom that one copy at prepare time is
+// the largest allocation the process makes, and it is repeated on every epoch
+// change. Here nothing is read but the directory entry itself; the first
+// UpdateDir reads the geometry and sizes the reader's buffers from maxEntries.
+//
+// maxEntries bounds entries per thread per refresh, and so bounds both the
+// buffers allocated and the work one refresh does; zero means the ring size. A
+// consumer draining a fast producer should set it and loop while any window
+// reports Pending. skipBacklog starts at the producer's head rather than at the
+// oldest entry still in the ring.
+//
+// name is matched exactly, not as a pattern: this returns one entry or an error,
+// because a caller reading a specific producer's records has nothing sensible to
+// do with a second ring that happened to match.
+func (sc *StatsClient) PrepareRingBuffer(name string, maxEntries uint32, skipBacklog bool) (*adapter.StatDir, error) {
+	sc.accessLock.RLock()
+	defer sc.accessLock.RUnlock()
+
+	if !sc.isConnected() {
+		return nil, adapter.ErrStatsDisconnected
+	}
+
+	accessEpoch := sc.accessStart()
+	if accessEpoch == 0 {
+		return nil, adapter.ErrStatsAccessFailed
+	}
+
+	vector := sc.GetDirectoryVector()
+	if vector == nil {
+		return nil, fmt.Errorf("failed to prepare ring buffer: directory vector is nil")
+	}
+
+	want := []byte(name)
+	var entry *adapter.StatEntry
+	vecLen := *(*uint32)(vectorLen(vector))
+	for i := uint32(0); i < vecLen; i++ {
+		// Compared in place: GetStatDirOnIndex clones every name it walks past,
+		// and on a real directory that is thousands of allocations to find one
+		// entry.
+		_, dirType, ok := sc.StatDirOnIndexMatches(vector, i, want)
+		if !ok {
+			continue
+		}
+		if dirType != adapter.RingBuffer {
+			return nil, fmt.Errorf("stat %q is %v, not a ring buffer", name, dirType)
+		}
+		entry = &adapter.StatEntry{
+			StatIdentifier: adapter.StatIdentifier{Index: i, Name: want},
+			Type:           adapter.RingBuffer,
+			Data: &adapter.RingBufferWindowStat{
+				MaxEntries:  maxEntries,
+				SkipBacklog: skipBacklog,
+			},
+		}
+		break
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("ring buffer stat %q not found", name)
+	}
+
+	if !sc.accessEnd(accessEpoch) {
+		return nil, adapter.ErrStatsDataBusy
+	}
+
+	return &adapter.StatDir{Epoch: accessEpoch, Entries: []adapter.StatEntry{*entry}}, nil
+}

--- a/adapter/statsclient/statseg_v2.go
+++ b/adapter/statsclient/statseg_v2.go
@@ -482,9 +482,15 @@ type ringBufferHeader struct {
 	DataOffset     uint32
 }
 
-// Respective VPP struct vlib_stats_ring_metadata_t is padded to 64 bytes for cache alignment
-const ringBufferMetaSize = 64
+// VPP pads vlib_stats_ring_metadata_t to CLIB_CACHE_LINE_BYTES, which
+// src/cmake/cpu.cmake sets to 128 on aarch64 and 64 everywhere else.
+const (
+	ringBufferMetaSize    = 64
+	ringBufferMetaSizeAlt = 128
+)
 
+// Only the leading fields are read; the stride between threads is
+// ringBufferMetaStride, not this struct's size.
 type ringBufferThreadMeta struct {
 	Head          uint32
 	SchemaVersion uint32
@@ -494,8 +500,39 @@ type ringBufferThreadMeta struct {
 	_             [40]byte // padding to cache line size
 }
 
+// ringBufferMetaStride returns the byte distance between adjacent threads'
+// metadata.
+//
+// A schema-bearing ring states it: VPP puts the schema directly after the
+// metadata array and records that offset in every thread's metadata, including
+// thread 0's, which sits at the start of the array whatever the stride is. So
+// the array's size, and from it the stride, follows from thread 0 alone.
+// Without a schema there is nothing to derive it from and 64 is assumed.
+func ringBufferMetaStride(base dirVector, header *ringBufferHeader, segSize uint64) uintptr {
+	if header.SchemaSize == 0 || header.NThreads == 0 {
+		return ringBufferMetaSize
+	}
+	if uint64(header.MetadataOffset)+ringBufferMetaSize > segSize {
+		return ringBufferMetaSize
+	}
+	meta := (*ringBufferThreadMeta)(unsafe.Pointer(
+		uintptr(unsafe.Pointer(base)) + uintptr(header.MetadataOffset),
+	))
+	schemaOffset := meta.SchemaOffset
+	if schemaOffset <= header.MetadataOffset {
+		return ringBufferMetaSize
+	}
+	metaSize := uint64(schemaOffset - header.MetadataOffset)
+	if stride := metaSize / uint64(header.NThreads); stride*uint64(header.NThreads) == metaSize {
+		if stride == ringBufferMetaSize || stride == ringBufferMetaSizeAlt {
+			return uintptr(stride)
+		}
+	}
+	return ringBufferMetaSize
+}
+
 func (ss *statSegmentV2) copyRingBufferData(dirEntry *statSegDirectoryEntryV2) adapter.Stat {
-	base, header, ok := ss.ringBufferRegions(dirEntry)
+	base, header, stride, ok := ss.ringBufferRegions(dirEntry)
 	if !ok {
 		return nil
 	}
@@ -510,7 +547,7 @@ func (ss *statSegmentV2) copyRingBufferData(dirEntry *statSegDirectoryEntryV2) a
 
 	threads := make([]adapter.RingBufferThreadMeta, header.NThreads)
 	for i := uint32(0); i < header.NThreads; i++ {
-		meta := ringBufferThreadMetaAt(base, header, i)
+		meta := ringBufferThreadMetaAt(base, header, stride, i)
 		threads[i] = adapter.RingBufferThreadMeta{
 			Head:          meta.Head,
 			SchemaVersion: meta.SchemaVersion,
@@ -534,7 +571,7 @@ func (ss *statSegmentV2) copyRingBufferData(dirEntry *statSegDirectoryEntryV2) a
 	return adapter.RingBufferStat{
 		Config:  config,
 		Threads: threads,
-		Schema:  ss.ringBufferSchema(base, threads, dirEntry.name[:]),
+		Schema:  ss.ringBufferSchema(base, threads, dirEntry),
 		Data:    data,
 	}
 }
@@ -587,44 +624,54 @@ func (ss *statSegmentV2) getSymlinkIndexes(dirEntry *statSegDirectoryEntryV2) (i
 // tidiness: these checks are what stand between a corrupt or racing header and
 // an out-of-bounds read of the mapped segment, so a second copy of them is a
 // second chance to get one of them subtly wrong.
-func (ss *statSegmentV2) ringBufferRegions(dirEntry *statSegDirectoryEntryV2) (base dirVector, header *ringBufferHeader, ok bool) {
+func (ss *statSegmentV2) ringBufferRegions(dirEntry *statSegDirectoryEntryV2) (base dirVector, header *ringBufferHeader, stride uintptr, ok bool) {
 	base = ss.adjust(dirVector(&dirEntry.unionData))
 	if base == nil {
 		debugf("ring buffer data pointer is out of range for %s", dirEntry.name)
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 
 	baseAddr := uintptr(unsafe.Pointer(base))
 	segEnd := uintptr(unsafe.Pointer(&ss.sharedHeader[len(ss.sharedHeader)-1])) + 1
+	if baseAddr >= segEnd {
+		debugf("ring buffer base is outside shared memory for %s", dirEntry.name)
+		return nil, nil, 0, false
+	}
+	// Every region is sized against the room left in the segment rather than by
+	// forming its end address, because a header claiming absurd geometry makes
+	// base+offset+size wrap and compare as if it fit.
+	segSize := uint64(segEnd - baseAddr)
 
-	if baseAddr+unsafe.Sizeof(ringBufferHeader{}) > segEnd {
+	if uint64(unsafe.Sizeof(ringBufferHeader{})) > segSize {
 		debugf("ring buffer header extends beyond shared memory for %s", dirEntry.name)
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	header = (*ringBufferHeader)(unsafe.Pointer(base))
 
-	metaEnd := baseAddr + uintptr(header.MetadataOffset) + uintptr(header.NThreads)*ringBufferMetaSize
-	if metaEnd > segEnd {
-		debugf("ring buffer metadata extends beyond shared memory for %s (metaEnd=%d, segEnd=%d)",
-			dirEntry.name, metaEnd, segEnd)
-		return nil, nil, false
+	stride = ringBufferMetaStride(base, header, segSize)
+	if uint64(header.MetadataOffset) > segSize ||
+		uint64(header.NThreads) > (segSize-uint64(header.MetadataOffset))/uint64(stride) {
+		debugf("ring buffer metadata extends beyond shared memory for %s (offset=%d, threads=%d, segSize=%d)",
+			dirEntry.name, header.MetadataOffset, header.NThreads, segSize)
+		return nil, nil, 0, false
 	}
 
-	threadDataSize := uintptr(header.RingSize) * uintptr(header.EntrySize)
-	dataEnd := baseAddr + uintptr(header.DataOffset) + uintptr(header.NThreads)*threadDataSize
-	if dataEnd > segEnd {
-		debugf("ring buffer data extends beyond shared memory for %s (dataEnd=%d, segEnd=%d)",
-			dirEntry.name, dataEnd, segEnd)
-		return nil, nil, false
+	// Both factors are uint32, so the product cannot overflow uint64.
+	threadDataSize := uint64(header.RingSize) * uint64(header.EntrySize)
+	if uint64(header.DataOffset) > segSize || (threadDataSize > 0 &&
+		uint64(header.NThreads) > (segSize-uint64(header.DataOffset))/threadDataSize) {
+		debugf("ring buffer data extends beyond shared memory for %s (offset=%d, threads=%d, segSize=%d)",
+			dirEntry.name, header.DataOffset, header.NThreads, segSize)
+		return nil, nil, 0, false
 	}
 
-	return base, header, true
+	return base, header, stride, true
 }
 
 // ringBufferThreadMetaAt returns thread t's producer metadata.
-func ringBufferThreadMetaAt(base dirVector, header *ringBufferHeader, t uint32) *ringBufferThreadMeta {
+func ringBufferThreadMetaAt(base dirVector, header *ringBufferHeader, stride uintptr, t uint32) *ringBufferThreadMeta {
 	return (*ringBufferThreadMeta)(unsafe.Pointer(
-		uintptr(unsafe.Pointer(base)) + uintptr(header.MetadataOffset) + uintptr(t)*ringBufferMetaSize,
+		uintptr(unsafe.Pointer(base)) + uintptr(header.MetadataOffset) + uintptr(t)*stride,
 	))
 }
 
@@ -638,7 +685,7 @@ func ringBufferThreadData(base dirVector, header *ringBufferHeader, t uint32) []
 
 // ringBufferSchema copies the schema blob from the first thread that publishes
 // one, or returns nil when none does.
-func (ss *statSegmentV2) ringBufferSchema(base dirVector, threads []adapter.RingBufferThreadMeta, name []byte) []byte {
+func (ss *statSegmentV2) ringBufferSchema(base dirVector, threads []adapter.RingBufferThreadMeta, dirEntry *statSegDirectoryEntryV2) []byte {
 	baseAddr := uintptr(unsafe.Pointer(base))
 	segEnd := uintptr(unsafe.Pointer(&ss.sharedHeader[len(ss.sharedHeader)-1])) + 1
 	for _, t := range threads {
@@ -646,7 +693,7 @@ func (ss *statSegmentV2) ringBufferSchema(base dirVector, threads []adapter.Ring
 			continue
 		}
 		if baseAddr+uintptr(t.SchemaOffset)+uintptr(t.SchemaSize) > segEnd {
-			debugf("ring buffer schema extends beyond shared memory for %s", name)
+			debugf("ring buffer schema extends beyond shared memory for %s", dirEntry.name)
 			continue
 		}
 		// Derived from base in one expression: a uintptr held across statements
@@ -677,11 +724,13 @@ var ringWindowCopyHook func()
 // the producer has not written since we last looked. The cost of a refresh is
 // the entries produced, not the size of the ring they were produced into.
 func (ss *statSegmentV2) refreshRingBufferWindow(dirEntry *statSegDirectoryEntryV2, s *adapter.RingBufferWindowStat) error {
-	base, header, ok := ss.ringBufferRegions(dirEntry)
+	base, header, stride, ok := ss.ringBufferRegions(dirEntry)
 	if !ok {
 		return ErrStatDataLenIncorrect
 	}
 	if header.EntrySize == 0 || header.RingSize == 0 || header.NThreads == 0 {
+		debugf("ring buffer has zero geometry for %s (entry_size=%d, ring_size=%d, threads=%d)",
+			dirEntry.name, header.EntrySize, header.RingSize, header.NThreads)
 		return ErrStatDataLenIncorrect
 	}
 
@@ -710,7 +759,7 @@ func (ss *statSegmentV2) refreshRingBufferWindow(dirEntry *statSegDirectoryEntry
 	}
 
 	for t := uint32(0); t < header.NThreads; t++ {
-		meta := ringBufferThreadMetaAt(base, header, t)
+		meta := ringBufferThreadMetaAt(base, header, stride, t)
 		// The sequence is the only field of the pair that carries an ordering
 		// guarantee: a producer writes the entry, advances head with a plain
 		// store, and then publishes the sequence with a release store. So a
@@ -741,6 +790,10 @@ func (ss *statSegmentV2) refreshRingBufferWindow(dirEntry *statSegDirectoryEntry
 			// also returned a ring of history would make "what happened since I
 			// last looked" mean something different on the first call than on
 			// every later one.
+			//
+			// A geometry change mid-stream reaches here too, SchemaVersion
+			// included, so with SkipBacklog whatever the ring already held is
+			// dropped without appearing in Lost.
 			if s.SkipBacklog {
 				w.NextSeq = seq
 			} else {
@@ -840,7 +893,7 @@ func (ss *statSegmentV2) refreshRingBufferWindow(dirEntry *statSegDirectoryEntry
 	}
 
 	if s.Schema == nil || reinit {
-		s.Schema = ss.ringBufferSchema(base, s.Threads, dirEntry.name[:])
+		s.Schema = ss.ringBufferSchema(base, s.Threads, dirEntry)
 	}
 	return nil
 }

--- a/adapter/statsclient/statseg_v2.go
+++ b/adapter/statsclient/statseg_v2.go
@@ -288,7 +288,7 @@ func (ss *statSegmentV2) CopyEntryData(segment dirSegment, index uint32) adapter
 
 func (ss *statSegmentV2) UpdateEntryData(segment dirSegment, stat *adapter.Stat) error {
 	dirEntry := (*statSegDirectoryEntryV2)(segment)
-	switch (*stat).(type) {
+	switch s := (*stat).(type) {
 	case adapter.ScalarStat:
 		*stat = adapter.ScalarStat(dirEntry.unionData)
 
@@ -423,6 +423,14 @@ func (ss *statSegmentV2) UpdateEntryData(segment dirSegment, stat *adapter.Stat)
 		}
 		*stat = ringBufferStat
 
+	case *adapter.RingBufferWindowStat:
+		// Refreshed in place: the point of a window stat is that neither the copy
+		// nor the allocation scales with ring size, so it must not be replaced by
+		// a fresh value the way the other cases are.
+		if err := ss.refreshRingBufferWindow(dirEntry, s); err != nil {
+			return err
+		}
+
 	default:
 		if Debug {
 			Log.Debugf("Unrecognized stat type %T for stat entry: %v", stat, dirEntry.name)
@@ -487,40 +495,8 @@ type ringBufferThreadMeta struct {
 }
 
 func (ss *statSegmentV2) copyRingBufferData(dirEntry *statSegDirectoryEntryV2) adapter.Stat {
-	base := ss.adjust(dirVector(&dirEntry.unionData))
-	if base == nil {
-		debugf("ring buffer data pointer is out of range for %s", dirEntry.name)
-		return nil
-	}
-
-	// Get start and end of ring buffer entry mapped region.
-	baseAddr := uintptr(unsafe.Pointer(base))
-	segEnd := uintptr(unsafe.Pointer(&ss.sharedHeader[len(ss.sharedHeader)-1])) + 1
-
-	// Verify the ring buffer header fits within the mapped region.
-	headerSize := unsafe.Sizeof(ringBufferHeader{})
-	if baseAddr+headerSize > segEnd {
-		debugf("ring buffer header extends beyond shared memory for %s", dirEntry.name)
-		return nil
-	}
-
-	// Cast to header struct instead of reading fields individually.
-	header := (*ringBufferHeader)(unsafe.Pointer(base))
-
-	// Verify metadata region fits within the mapped region.
-	metaEnd := baseAddr + uintptr(header.MetadataOffset) + uintptr(header.NThreads)*ringBufferMetaSize
-	if metaEnd > segEnd {
-		debugf("ring buffer metadata extends beyond shared memory for %s (metaEnd=%d, segEnd=%d)",
-			dirEntry.name, metaEnd, segEnd)
-		return nil
-	}
-
-	// Verify data region fits within the mapped region.
-	threadDataSize := uintptr(header.RingSize) * uintptr(header.EntrySize)
-	dataEnd := baseAddr + uintptr(header.DataOffset) + uintptr(header.NThreads)*threadDataSize
-	if dataEnd > segEnd {
-		debugf("ring buffer data extends beyond shared memory for %s (dataEnd=%d, segEnd=%d)",
-			dirEntry.name, dataEnd, segEnd)
+	base, header, ok := ss.ringBufferRegions(dirEntry)
+	if !ok {
 		return nil
 	}
 
@@ -532,12 +508,9 @@ func (ss *statSegmentV2) copyRingBufferData(dirEntry *statSegDirectoryEntryV2) a
 		SchemaVersion: header.SchemaVersion,
 	}
 
-	// Read per-thread metadata by casting to the raw struct.
 	threads := make([]adapter.RingBufferThreadMeta, header.NThreads)
 	for i := uint32(0); i < header.NThreads; i++ {
-		meta := (*ringBufferThreadMeta)(unsafe.Pointer(
-			baseAddr + uintptr(header.MetadataOffset) + uintptr(i)*ringBufferMetaSize,
-		))
+		meta := ringBufferThreadMetaAt(base, header, i)
 		threads[i] = adapter.RingBufferThreadMeta{
 			Head:          meta.Head,
 			SchemaVersion: meta.SchemaVersion,
@@ -547,38 +520,21 @@ func (ss *statSegmentV2) copyRingBufferData(dirEntry *statSegDirectoryEntryV2) a
 		}
 	}
 
-	// Read schema from the first thread that has one.
-	var schema []byte
-	for _, t := range threads {
-		if t.SchemaSize > 0 && t.SchemaOffset > 0 {
-			schemaEnd := baseAddr + uintptr(t.SchemaOffset) + uintptr(t.SchemaSize)
-			if schemaEnd > segEnd {
-				debugf("ring buffer schema extends beyond shared memory for %s (schemaEnd=%d, segEnd=%d)",
-					dirEntry.name, schemaEnd, segEnd)
-				continue
-			}
-			schemaPtr := unsafe.Pointer(baseAddr + uintptr(t.SchemaOffset))
-			srcSchema := unsafe.Slice((*byte)(schemaPtr), t.SchemaSize)
-			schema = make([]byte, t.SchemaSize)
-			copy(schema, srcSchema)
-			break
-		}
-	}
-
-	// Copy per-thread raw ring data.
+	// Copy every thread's whole ring. This is what adapter.RingBufferWindowStat
+	// exists to avoid: the cost here is the ring's size, not the entries anyone
+	// has produced into it.
 	data := make([][]byte, header.NThreads)
 	for i := uint32(0); i < header.NThreads; i++ {
-		srcPtr := unsafe.Pointer(baseAddr + uintptr(header.DataOffset) + uintptr(i)*threadDataSize)
-		srcSlice := unsafe.Slice((*byte)(srcPtr), threadDataSize)
-		threadData := make([]byte, threadDataSize)
-		copy(threadData, srcSlice)
+		src := ringBufferThreadData(base, header, i)
+		threadData := make([]byte, len(src))
+		copy(threadData, src)
 		data[i] = threadData
 	}
 
 	return adapter.RingBufferStat{
 		Config:  config,
 		Threads: threads,
-		Schema:  schema,
+		Schema:  ss.ringBufferSchema(base, threads, dirEntry.name[:]),
 		Data:    data,
 	}
 }
@@ -622,4 +578,269 @@ func (ss *statSegmentV2) getSymlinkIndexes(dirEntry *statSegDirectoryEntryV2) (i
 	// little-endian and reassembled it little-endian, so it round-tripped to the
 	// same numeric value on any host. Shifting does the same, without the buffer.
 	return uint32(dirEntry.unionData), uint32(dirEntry.unionData >> 32)
+}
+
+// ringBufferRegions resolves and bounds-checks the three regions of a ring
+// buffer entry: its header, its per-thread metadata and its data.
+//
+// Every read of a ring has to do this, and doing it in one place is not only
+// tidiness: these checks are what stand between a corrupt or racing header and
+// an out-of-bounds read of the mapped segment, so a second copy of them is a
+// second chance to get one of them subtly wrong.
+func (ss *statSegmentV2) ringBufferRegions(dirEntry *statSegDirectoryEntryV2) (base dirVector, header *ringBufferHeader, ok bool) {
+	base = ss.adjust(dirVector(&dirEntry.unionData))
+	if base == nil {
+		debugf("ring buffer data pointer is out of range for %s", dirEntry.name)
+		return nil, nil, false
+	}
+
+	baseAddr := uintptr(unsafe.Pointer(base))
+	segEnd := uintptr(unsafe.Pointer(&ss.sharedHeader[len(ss.sharedHeader)-1])) + 1
+
+	if baseAddr+unsafe.Sizeof(ringBufferHeader{}) > segEnd {
+		debugf("ring buffer header extends beyond shared memory for %s", dirEntry.name)
+		return nil, nil, false
+	}
+	header = (*ringBufferHeader)(unsafe.Pointer(base))
+
+	metaEnd := baseAddr + uintptr(header.MetadataOffset) + uintptr(header.NThreads)*ringBufferMetaSize
+	if metaEnd > segEnd {
+		debugf("ring buffer metadata extends beyond shared memory for %s (metaEnd=%d, segEnd=%d)",
+			dirEntry.name, metaEnd, segEnd)
+		return nil, nil, false
+	}
+
+	threadDataSize := uintptr(header.RingSize) * uintptr(header.EntrySize)
+	dataEnd := baseAddr + uintptr(header.DataOffset) + uintptr(header.NThreads)*threadDataSize
+	if dataEnd > segEnd {
+		debugf("ring buffer data extends beyond shared memory for %s (dataEnd=%d, segEnd=%d)",
+			dirEntry.name, dataEnd, segEnd)
+		return nil, nil, false
+	}
+
+	return base, header, true
+}
+
+// ringBufferThreadMetaAt returns thread t's producer metadata.
+func ringBufferThreadMetaAt(base dirVector, header *ringBufferHeader, t uint32) *ringBufferThreadMeta {
+	return (*ringBufferThreadMeta)(unsafe.Pointer(
+		uintptr(unsafe.Pointer(base)) + uintptr(header.MetadataOffset) + uintptr(t)*ringBufferMetaSize,
+	))
+}
+
+// ringBufferThreadData returns thread t's ring as a slice over the mapped
+// segment. Read-only: it aliases shared memory a VPP worker is writing.
+func ringBufferThreadData(base dirVector, header *ringBufferHeader, t uint32) []byte {
+	threadDataSize := uintptr(header.RingSize) * uintptr(header.EntrySize)
+	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(base)) + uintptr(header.DataOffset) + uintptr(t)*threadDataSize)
+	return unsafe.Slice((*byte)(ptr), threadDataSize)
+}
+
+// ringBufferSchema copies the schema blob from the first thread that publishes
+// one, or returns nil when none does.
+func (ss *statSegmentV2) ringBufferSchema(base dirVector, threads []adapter.RingBufferThreadMeta, name []byte) []byte {
+	baseAddr := uintptr(unsafe.Pointer(base))
+	segEnd := uintptr(unsafe.Pointer(&ss.sharedHeader[len(ss.sharedHeader)-1])) + 1
+	for _, t := range threads {
+		if t.SchemaSize == 0 || t.SchemaOffset == 0 {
+			continue
+		}
+		if baseAddr+uintptr(t.SchemaOffset)+uintptr(t.SchemaSize) > segEnd {
+			debugf("ring buffer schema extends beyond shared memory for %s", name)
+			continue
+		}
+		// Derived from base in one expression: a uintptr held across statements
+		// and converted back loses its provenance, which is undefined and what
+		// checkptr rejects under -race.
+		src := unsafe.Slice((*byte)(unsafe.Pointer(
+			uintptr(unsafe.Pointer(base))+uintptr(t.SchemaOffset))), t.SchemaSize)
+		schema := make([]byte, t.SchemaSize)
+		copy(schema, src)
+		return schema
+	}
+	return nil
+}
+
+// ringWindowCopyHook runs between a window's entries being copied out of the
+// segment and their validation against the producer. It is nil in production and
+// costs one nil check per thread per refresh; it exists because the case the
+// validation is there for - a worker overwriting the slots while the copy runs -
+// is otherwise reachable only by racing a real producer, which is not something
+// a test can assert on.
+var ringWindowCopyHook func()
+
+// refreshRingBufferWindow copies, for each producer thread, only the entries
+// appended since the previous refresh - into buffers the stat already owns.
+//
+// This is the whole reason the type exists, so it is worth being explicit about
+// what is not here: no allocation on the steady path, and no read of any slot
+// the producer has not written since we last looked. The cost of a refresh is
+// the entries produced, not the size of the ring they were produced into.
+func (ss *statSegmentV2) refreshRingBufferWindow(dirEntry *statSegDirectoryEntryV2, s *adapter.RingBufferWindowStat) error {
+	base, header, ok := ss.ringBufferRegions(dirEntry)
+	if !ok {
+		return ErrStatDataLenIncorrect
+	}
+	if header.EntrySize == 0 || header.RingSize == 0 || header.NThreads == 0 {
+		return ErrStatDataLenIncorrect
+	}
+
+	cfg := adapter.RingBufferConfig{
+		EntrySize:     header.EntrySize,
+		RingSize:      header.RingSize,
+		NThreads:      header.NThreads,
+		SchemaSize:    header.SchemaSize,
+		SchemaVersion: header.SchemaVersion,
+	}
+
+	// A geometry change invalidates both the buffers, which are sized from it,
+	// and the cursors, which are positions within it. Treat it as a first read
+	// rather than trying to carry a cursor across a ring that is no longer the
+	// same ring.
+	reinit := s.Config != cfg || len(s.Windows) != int(header.NThreads)
+	if reinit {
+		s.Config = cfg
+		s.Threads = make([]adapter.RingBufferThreadMeta, header.NThreads)
+		s.Windows = make([]adapter.RingBufferWindow, header.NThreads)
+	}
+
+	maxEntries := s.MaxEntries
+	if maxEntries == 0 || maxEntries > header.RingSize {
+		maxEntries = header.RingSize
+	}
+
+	for t := uint32(0); t < header.NThreads; t++ {
+		meta := ringBufferThreadMetaAt(base, header, t)
+		// The sequence is the only field of the pair that carries an ordering
+		// guarantee: a producer writes the entry, advances head with a plain
+		// store, and then publishes the sequence with a release store. So a
+		// consumer that reads both can see a head one slot ahead of the sequence
+		// that explains it, and everything below positions off the sequence
+		// alone. Head is loaded only to report it.
+		head := atomic.LoadUint32(&meta.Head)
+		seq := atomic.LoadUint64(&meta.Sequence)
+
+		s.Threads[t] = adapter.RingBufferThreadMeta{
+			Head:          head,
+			SchemaVersion: meta.SchemaVersion,
+			Sequence:      seq,
+			SchemaOffset:  meta.SchemaOffset,
+			SchemaSize:    meta.SchemaSize,
+		}
+
+		w := &s.Windows[t]
+		w.Lost, w.Pending, w.Count = 0, 0, 0
+
+		if cap(w.Entries) < int(maxEntries)*int(header.EntrySize) {
+			w.Entries = make([]byte, 0, int(maxEntries)*int(header.EntrySize))
+		}
+		buf := w.Entries[:cap(w.Entries)]
+
+		if reinit {
+			// Position the cursor without delivering anything. A first read that
+			// also returned a ring of history would make "what happened since I
+			// last looked" mean something different on the first call than on
+			// every later one.
+			if s.SkipBacklog {
+				w.NextSeq = seq
+			} else {
+				w.NextSeq = seq - min(seq, uint64(header.RingSize))
+			}
+			w.FirstSeq = w.NextSeq
+			w.Entries = buf[:0]
+			continue
+		}
+
+		if seq < w.NextSeq {
+			// The producer's sequence went backwards: VPP restarted, or the entry
+			// was reused for a different ring. Re-sync to what is there now and do
+			// not report it as loss - nothing was overwritten, the count simply is
+			// not comparable to the one we held.
+			w.NextSeq = seq - min(seq, uint64(header.RingSize))
+		}
+
+		available := seq - w.NextSeq
+		if available > uint64(header.RingSize) {
+			// Lapped: everything older than the last RingSize entries is gone.
+			w.Lost = available - uint64(header.RingSize)
+			w.NextSeq = seq - uint64(header.RingSize)
+			available = uint64(header.RingSize)
+		}
+
+		deliver := available
+		if deliver > uint64(maxEntries) {
+			deliver = uint64(maxEntries)
+			w.Pending = available - deliver
+		}
+
+		w.FirstSeq = w.NextSeq
+		if deliver == 0 {
+			w.Entries = buf[:0]
+			continue
+		}
+
+		// The entry with sequence x sits at slot x mod RingSize. Head is not used
+		// to find it: head and the sequence both start at zero and advance
+		// together on every commit, so head is congruent to the sequence and
+		// carries no information the sequence does not - but it is published
+		// first and without a barrier, so deriving the slot from it delivers the
+		// slot a worker is writing right now whenever the two are read astride a
+		// commit.
+		first := uint32(w.NextSeq % uint64(header.RingSize))
+
+		data := ringBufferThreadData(base, header, t)
+		entry := uintptr(header.EntrySize)
+		n := uint32(deliver)
+
+		// At most two copies: the run up to the ring's seam, then the rest from
+		// slot zero. The consumer sees them unwrapped and never learns where the
+		// seam was.
+		firstRun := header.RingSize - first
+		if firstRun > n {
+			firstRun = n
+		}
+		copy(buf[:uintptr(firstRun)*entry], data[uintptr(first)*entry:uintptr(first+firstRun)*entry])
+		if rest := n - firstRun; rest > 0 {
+			copy(buf[uintptr(firstRun)*entry:uintptr(n)*entry], data[:uintptr(rest)*entry])
+		}
+
+		if ringWindowCopyHook != nil {
+			ringWindowCopyHook()
+		}
+
+		// Check the copy against the producer, which did not stop while it ran:
+		// the segment's optimistic lock covers directory changes, not ring data,
+		// so a worker is free to overwrite the slots being copied. Anything older
+		// than seqAfter-RingSize was overwritten underneath us, and those are the
+		// oldest entries of the window, so dropping them from the front of the
+		// buffer leaves exactly the ones that are still whole.
+		//
+		// Without this a lapped reader delivers entries that are half one record
+		// and half another and reports no loss, which is worse than losing them:
+		// loss is visible and a torn record is not.
+		windowStart := w.NextSeq
+		if seqAfter := atomic.LoadUint64(&meta.Sequence); seqAfter > uint64(header.RingSize) {
+			if oldest := seqAfter - uint64(header.RingSize); oldest > windowStart {
+				overrun := min(oldest-windowStart, uint64(n))
+				if overrun < uint64(n) {
+					copy(buf, buf[uintptr(overrun)*entry:uintptr(n)*entry])
+				}
+				w.Lost += overrun
+				n -= uint32(overrun)
+			}
+		}
+
+		w.Count = n
+		w.NextSeq += deliver
+		// Derived rather than remembered, so it stays right when the check above
+		// drops entries from the front: FirstSeq is the sequence of Entries[0],
+		// and equals NextSeq when nothing was delivered.
+		w.FirstSeq = w.NextSeq - uint64(n)
+		w.Entries = buf[:uintptr(n)*entry]
+	}
+
+	if s.Schema == nil || reinit {
+		s.Schema = ss.ringBufferSchema(base, s.Threads, dirEntry.name[:])
+	}
+	return nil
 }

--- a/adapter/statsclient/statseg_v2_ring_test.go
+++ b/adapter/statsclient/statseg_v2_ring_test.go
@@ -1,0 +1,511 @@
+//  Copyright (c) 2026 Meter, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package statsclient
+
+import (
+	"encoding/binary"
+	"sync/atomic"
+	"testing"
+	"unsafe"
+
+	"go.fd.io/govpp/adapter"
+)
+
+// A synthetic v2 segment holding one ring-buffer stat, laid out as VPP lays one
+// out, so the windowed reader's slot arithmetic can be exercised without a
+// running VPP.
+//
+//	index 0: /sys/fake-scalar   filler, so the ring is not at index 0
+//	index 1: /fake/records      the ring
+//
+// Each entry's first eight bytes are the producer sequence that wrote it, which
+// is what lets a test assert ordering and unwrapping without reimplementing
+// either.
+const (
+	fakeRingIndex      = 1
+	fakeTypeRingBuffer = 8
+	fakeRingSchema     = `{"name":"fake.record","version":1,"entry_size":16,"fields":[]}`
+)
+
+type fakeRing struct {
+	buf       []byte
+	ringBase  int // offset of the ring buffer's own header
+	dataOff   int // relative to ringBase
+	metaOff   int // relative to ringBase
+	entrySize uint32
+	ringSize  uint32
+	nThreads  uint32
+	head      []uint32
+	seq       []uint64
+}
+
+func newFakeRing(t testing.TB, entrySize, ringSize, nThreads uint32) *fakeRing {
+	t.Helper()
+
+	const (
+		hdrSize   = 64
+		vecHdr    = 8
+		trailer   = 8
+		nDir      = fakeRingIndex + 1
+		dirEntLen = int(unsafe.Sizeof(statSegDirectoryEntryV2{}))
+	)
+
+	dirLenOff := hdrSize
+	dirOff := dirLenOff + vecHdr
+	ringBase := align8(dirOff + nDir*dirEntLen)
+
+	// Offsets below are relative to ringBase, which is what the header declares.
+	metaOff := 64 // past the ring header, cache-line aligned as VPP has it
+	schemaOff := metaOff + int(nThreads)*ringBufferMetaSize
+	dataOff := align8(schemaOff + len(fakeRingSchema) + 1)
+	total := ringBase + dataOff + int(nThreads)*int(ringSize)*int(entrySize) + trailer
+
+	f := &fakeRing{
+		buf:       make([]byte, total),
+		ringBase:  ringBase,
+		dataOff:   dataOff,
+		metaOff:   metaOff,
+		entrySize: entrySize,
+		ringSize:  ringSize,
+		nThreads:  nThreads,
+		head:      make([]uint32, nThreads),
+		seq:       make([]uint64, nThreads),
+	}
+
+	f.putU64(fakeOffVersion, 2)
+	f.putU64(fakeOffBase, fakeBase)
+	f.putU64(fakeOffEpoch, 1)
+	f.putU64(fakeOffInProgress, 0)
+	f.putU64(fakeOffDirVector, fakeBase+uint64(dirOff))
+	f.putU64(fakeOffErrorVector, 0)
+	f.putU64(dirLenOff, nDir)
+
+	f.putDirEntry(dirOff, 0, fakeTypeScalarIndex, 7, "/sys/fake-scalar")
+	f.putDirEntry(dirOff, fakeRingIndex, fakeTypeRingBuffer, fakeBase+uint64(ringBase), "/fake/records")
+
+	// The ring's own header.
+	f.putU32(ringBase+0, entrySize)
+	f.putU32(ringBase+4, ringSize)
+	f.putU32(ringBase+8, nThreads)
+	f.putU32(ringBase+12, uint32(len(fakeRingSchema)+1))
+	f.putU32(ringBase+16, 1) // schema version
+	f.putU32(ringBase+20, uint32(metaOff))
+	f.putU32(ringBase+24, uint32(dataOff))
+
+	copy(f.buf[ringBase+schemaOff:], fakeRingSchema)
+
+	for i := uint32(0); i < nThreads; i++ {
+		m := ringBase + metaOff + int(i)*ringBufferMetaSize
+		f.putU32(m+0, 0)                  // head
+		f.putU32(m+4, 1)                  // schema version
+		f.putU64(m+8, 0)                  // sequence
+		f.putU32(m+16, uint32(schemaOff)) // schema offset
+		f.putU32(m+20, uint32(len(fakeRingSchema)+1))
+	}
+	return f
+}
+
+func align8(n int) int { return (n + 7) &^ 7 }
+
+func (f *fakeRing) putU64(off int, v uint64) { *(*uint64)(unsafe.Pointer(&f.buf[off])) = v }
+func (f *fakeRing) putU32(off int, v uint32) { *(*uint32)(unsafe.Pointer(&f.buf[off])) = v }
+
+func (f *fakeRing) putDirEntry(dirOff, index int, typ dirType, union uint64, name string) {
+	e := (*statSegDirectoryEntryV2)(unsafe.Pointer(&f.buf[dirOff+index*int(unsafe.Sizeof(statSegDirectoryEntryV2{}))]))
+	e.directoryType = typ
+	e.unionData = union
+	copy(e.name[:], name)
+	e.name[len(name)] = 0
+}
+
+// produce writes n entries as a VPP worker would: entry body first, then the
+// head and sequence that publish it.
+func (f *fakeRing) produce(thread uint32, n int) {
+	for i := 0; i < n; i++ {
+		slot := f.head[thread]
+		off := f.ringBase + f.dataOff +
+			int(thread)*int(f.ringSize)*int(f.entrySize) +
+			int(slot)*int(f.entrySize)
+		binary.LittleEndian.PutUint64(f.buf[off:], f.seq[thread])
+		f.head[thread] = (slot + 1) % f.ringSize
+		f.seq[thread]++
+	}
+	m := f.ringBase + f.metaOff + int(thread)*ringBufferMetaSize
+	f.putU32(m+0, f.head[thread])
+	f.putU64(m+8, f.seq[thread])
+}
+
+// rewindSequence makes the producer's count go backwards, as a VPP restart on
+// the same segment would.
+// publishHeadAhead advances the published head by one without publishing the
+// sequence that explains it. That is the state a producer is in between its
+// plain store of head and its release store of the sequence, and it is what a
+// consumer sees when it reads the two astride a commit.
+func (f *fakeRing) publishHeadAhead(thread uint32) {
+	m := f.ringBase + f.metaOff + int(thread)*ringBufferMetaSize
+	f.putU32(m+0, (f.head[thread]+1)%f.ringSize)
+}
+
+func (f *fakeRing) rewindSequence(thread uint32, to uint64) {
+	f.seq[thread] = to
+	f.putU64(f.ringBase+f.metaOff+int(thread)*ringBufferMetaSize+8, to)
+}
+
+func (f *fakeRing) client() *StatsClient {
+	sc := &StatsClient{statSegment: newStatSegmentV2(f.buf, int64(len(f.buf)))}
+	atomic.StoreUint32(&sc.connected, 1)
+	return sc
+}
+
+// seqsOf decodes the sequence stamp out of each delivered entry.
+func seqsOf(t testing.TB, w adapter.RingBufferWindow, entrySize uint32) []uint64 {
+	t.Helper()
+	if len(w.Entries) != int(w.Count)*int(entrySize) {
+		t.Fatalf("Entries is %d bytes, want Count(%d)*entrySize(%d)=%d",
+			len(w.Entries), w.Count, entrySize, int(w.Count)*int(entrySize))
+	}
+	out := make([]uint64, w.Count)
+	for i := range out {
+		out[i] = binary.LittleEndian.Uint64(w.Entries[i*int(entrySize):])
+	}
+	return out
+}
+
+func prepareRing(t testing.TB, f *fakeRing, maxEntries uint32, skipBacklog bool) (*StatsClient, *adapter.StatDir, *adapter.RingBufferWindowStat) {
+	t.Helper()
+	sc := f.client()
+	dir, err := sc.PrepareRingBuffer("/fake/records", maxEntries, skipBacklog)
+	if err != nil {
+		t.Fatalf("PrepareRingBuffer: %v", err)
+	}
+	s, ok := dir.Entries[0].Data.(*adapter.RingBufferWindowStat)
+	if !ok {
+		t.Fatalf("prepared Data is %T, want *adapter.RingBufferWindowStat", dir.Entries[0].Data)
+	}
+	return sc, dir, s
+}
+
+func refresh(t testing.TB, sc *StatsClient, dir *adapter.StatDir) {
+	t.Helper()
+	if err := sc.UpdateDir(dir); err != nil {
+		t.Fatalf("UpdateDir: %v", err)
+	}
+}
+
+func wantWindow(t testing.TB, w adapter.RingBufferWindow, entrySize uint32, seqs []uint64, lost, pending uint64) {
+	t.Helper()
+	got := seqsOf(t, w, entrySize)
+	if len(got) != len(seqs) {
+		t.Fatalf("got %d entries %v, want %d %v", len(got), got, len(seqs), seqs)
+	}
+	for i := range got {
+		if got[i] != seqs[i] {
+			t.Fatalf("entry %d has sequence %d, want %d (got %v, want %v)", i, got[i], seqs[i], got, seqs)
+		}
+	}
+	if w.Lost != lost {
+		t.Errorf("Lost = %d, want %d", w.Lost, lost)
+	}
+	if w.Pending != pending {
+		t.Errorf("Pending = %d, want %d", w.Pending, pending)
+	}
+}
+
+// PrepareRingBuffer must not read the ring's contents, and the first refresh must
+// only position the cursor. A first read that also drained the ring would make
+// "what has been produced since I last looked" mean something different on the
+// first call than on every later one.
+func TestRingBufferWindowFirstRefreshOnlyPositions(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 1)
+	f.produce(0, 3)
+
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+
+	if s.Config.EntrySize != 16 || s.Config.RingSize != 8 || s.Config.NThreads != 1 {
+		t.Fatalf("config = %+v, want entry 16 ring 8 threads 1", s.Config)
+	}
+	if string(s.Schema) != fakeRingSchema+"\x00" {
+		t.Errorf("schema = %q, want %q", s.Schema, fakeRingSchema)
+	}
+	wantWindow(t, s.Windows[0], 16, nil, 0, 0)
+	if s.Windows[0].NextSeq != 0 {
+		t.Errorf("NextSeq = %d, want 0: the backlog must still be readable", s.Windows[0].NextSeq)
+	}
+
+	// The backlog is then delivered by the next read, in order.
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2}, 0, 0)
+}
+
+func TestRingBufferWindowSkipBacklog(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 1)
+	f.produce(0, 3)
+
+	sc, dir, s := prepareRing(t, f, 0, true)
+	refresh(t, sc, dir)
+	if s.Windows[0].NextSeq != 3 {
+		t.Fatalf("NextSeq = %d, want 3: SkipBacklog must start at the head", s.Windows[0].NextSeq)
+	}
+
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, nil, 0, 0)
+
+	f.produce(0, 2)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{3, 4}, 0, 0)
+}
+
+// Only what was appended since the last refresh, and nothing twice.
+func TestRingBufferWindowDeliversNewEntriesOnly(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 1)
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+
+	f.produce(0, 3)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2}, 0, 0)
+
+	// A refresh with nothing new must report nothing, not repeat itself.
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, nil, 0, 0)
+
+	f.produce(0, 2)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{3, 4}, 0, 0)
+}
+
+// A window that straddles the ring's seam must come back contiguous and in
+// order: the consumer is not told where the seam fell and must not have to care.
+func TestRingBufferWindowUnwrapsAcrossSeam(t *testing.T) {
+	f := newFakeRing(t, 16, 4, 1)
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+
+	f.produce(0, 3) // slots 0,1,2
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2}, 0, 0)
+
+	f.produce(0, 3) // slots 3,0,1 - wraps
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{3, 4, 5}, 0, 0)
+}
+
+// Overwritten entries are Lost - gone - and must be counted exactly, not
+// estimated and not silently skipped.
+func TestRingBufferWindowReportsLostOnLap(t *testing.T) {
+	f := newFakeRing(t, 16, 4, 1)
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+
+	f.produce(0, 10) // ring holds 4: sequences 6..9 survive, 0..5 are gone
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{6, 7, 8, 9}, 6, 0)
+
+	// And the reader is re-synced, so the next read is clean.
+	f.produce(0, 2)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{10, 11}, 0, 0)
+}
+
+// MaxEntries bounds one refresh. What it holds back is Pending, not Lost: it is
+// still in the ring and the next read delivers it. Conflating the two would tell
+// a rate-limited reader it was losing data.
+func TestRingBufferWindowCapsAtMaxEntriesAndReportsPending(t *testing.T) {
+	f := newFakeRing(t, 16, 16, 1)
+	sc, dir, s := prepareRing(t, f, 2, false)
+	refresh(t, sc, dir)
+
+	f.produce(0, 5)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1}, 0, 3)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{2, 3}, 0, 1)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{4}, 0, 0)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, nil, 0, 0)
+
+	// The buffer is sized from MaxEntries, not from the ring: that is what makes
+	// a ring sized for burst headroom affordable to read.
+	if got := cap(s.Windows[0].Entries); got != 2*16 {
+		t.Errorf("buffer capacity = %d, want %d (MaxEntries*EntrySize)", got, 2*16)
+	}
+}
+
+// A producer sequence that goes backwards means a restart, not loss: nothing was
+// overwritten, the count simply is no longer comparable.
+func TestRingBufferWindowResyncsOnSequenceRewind(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 1)
+	sc, dir, s := prepareRing(t, f, 0, true)
+	refresh(t, sc, dir)
+
+	f.produce(0, 5)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2, 3, 4}, 0, 0)
+
+	f.rewindSequence(0, 2)
+	refresh(t, sc, dir)
+	if s.Windows[0].Lost != 0 {
+		t.Errorf("Lost = %d after a sequence rewind, want 0: nothing was overwritten", s.Windows[0].Lost)
+	}
+	if s.Windows[0].NextSeq != 2 {
+		t.Errorf("NextSeq = %d, want 2: the reader must re-sync to what is there now", s.Windows[0].NextSeq)
+	}
+}
+
+func TestRingBufferWindowPerThread(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 3)
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+
+	if len(s.Windows) != 3 {
+		t.Fatalf("got %d windows, want 3", len(s.Windows))
+	}
+
+	f.produce(0, 2)
+	f.produce(2, 3)
+	refresh(t, sc, dir)
+
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1}, 0, 0)
+	wantWindow(t, s.Windows[1], 16, nil, 0, 0)
+	wantWindow(t, s.Windows[2], 16, []uint64{0, 1, 2}, 0, 0)
+}
+
+// The steady path must not allocate. A refresh that allocated per poll would put
+// the ring read back on the garbage collector's critical path, which is most of
+// what this type exists to get off it.
+func TestRingBufferWindowRefreshDoesNotAllocate(t *testing.T) {
+	f := newFakeRing(t, 128, 4096, 2)
+	sc, dir, _ := prepareRing(t, f, 512, true)
+	refresh(t, sc, dir)
+	f.produce(0, 64)
+	refresh(t, sc, dir)
+
+	allocs := testing.AllocsPerRun(50, func() {
+		f.produce(0, 64)
+		f.produce(1, 64)
+		if err := sc.UpdateDir(dir); err != nil {
+			t.Fatalf("UpdateDir: %v", err)
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("refresh allocated %v objects per run, want 0", allocs)
+	}
+}
+
+func TestPrepareRingBufferRejectsNonRing(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 1)
+	sc := f.client()
+	if _, err := sc.PrepareRingBuffer("/sys/fake-scalar", 0, false); err == nil {
+		t.Fatal("PrepareRingBuffer: no error for a stat that is not a ring buffer")
+	}
+	if _, err := sc.PrepareRingBuffer("/fake/nope", 0, false); err == nil {
+		t.Fatal("PrepareRingBuffer: no error for a missing stat")
+	}
+}
+
+// The measurement the design rests on: a refresh costs the entries produced,
+// where a full-ring read costs the ring. Run with -benchtime=1000x and compare.
+func BenchmarkRingBufferWindowRefresh(b *testing.B) {
+	f := newFakeRing(b, 128, 8192, 1)
+	sc, dir, _ := prepareRing(b, f, 512, true)
+	refresh(b, sc, dir)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.produce(0, 256)
+		if err := sc.UpdateDir(dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(256, "entries/op")
+}
+
+func BenchmarkRingBufferFullCopy(b *testing.B) {
+	f := newFakeRing(b, 128, 8192, 1)
+	sc := f.client()
+	dir, err := sc.PrepareDir("/fake/records")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.produce(0, 256)
+		if err := sc.UpdateDir(dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(256, "entries/op")
+}
+
+// A head that has run ahead of its sequence must not move the window. Slots are
+// found from the sequence, which is the only field the producer publishes with a
+// barrier; positioning off head would deliver the slot being written and skip the
+// oldest live entry, and would do it only under load.
+func TestRingBufferWindowIgnoresHeadAheadOfSequence(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 1)
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+
+	f.produce(0, 3)
+	f.publishHeadAhead(0)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2}, 0, 0)
+
+	// And the cursor is still where the sequence says, so the next refresh
+	// continues rather than repeating or skipping.
+	f.produce(0, 2)
+	f.publishHeadAhead(0)
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{3, 4}, 0, 0)
+}
+
+// The segment's optimistic lock covers directory changes, not ring data, so a
+// worker can overwrite the slots a refresh is copying. What survives must be
+// whole, and what did not must be reported as lost: a torn record delivered as
+// good is worse than a lost one, because loss is visible and tearing is not.
+func TestRingBufferWindowDropsEntriesOverwrittenDuringCopy(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 1)
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+
+	f.produce(0, 8) // fills the ring: sequences 0..7
+
+	// Three more entries land while the copy is in flight, overwriting the three
+	// oldest slots it just read.
+	ringWindowCopyHook = func() {
+		ringWindowCopyHook = nil
+		f.produce(0, 3)
+	}
+	t.Cleanup(func() { ringWindowCopyHook = nil })
+
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{3, 4, 5, 6, 7}, 3, 0)
+	if s.Windows[0].FirstSeq != 3 {
+		t.Errorf("FirstSeq = %d, want 3: it must name the first entry actually delivered",
+			s.Windows[0].FirstSeq)
+	}
+
+	// The cursor is past the whole window, overwritten entries included, so the
+	// next refresh picks up the three that arrived during the copy.
+	refresh(t, sc, dir)
+	wantWindow(t, s.Windows[0], 16, []uint64{8, 9, 10}, 0, 0)
+}

--- a/adapter/statsclient/statseg_v2_ring_test.go
+++ b/adapter/statsclient/statseg_v2_ring_test.go
@@ -17,6 +17,7 @@ package statsclient
 import (
 	"encoding/binary"
 	"fmt"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"unsafe"
@@ -168,6 +169,22 @@ func (f *fakeRing) publishHeadAhead(thread uint32) {
 	f.putU32(m+0, (f.head[thread]+1)%f.ringSize)
 }
 
+// dropSchema clears the schema the ring advertises, as a ring registered with
+// schema_size 0 has it. The metadata array keeps its stride; nothing states it
+// any more.
+func (f *fakeRing) dropSchema() {
+	f.putU32(f.ringBase+12, 0)
+	for i := uint32(0); i < f.nThreads; i++ {
+		m := f.ringBase + f.metaOff + int(i)*f.metaStride
+		f.putU32(m+16, 0)
+		f.putU32(m+20, 0)
+	}
+}
+
+// setHeader overwrites one of the ring header's u32 fields, to stand in for a
+// header that is corrupt or being rewritten as it is read.
+func (f *fakeRing) setHeader(off int, v uint32) { f.putU32(f.ringBase+off, v) }
+
 // rewindSequence makes the producer's count go backwards, as a VPP restart on
 // the same segment would.
 func (f *fakeRing) rewindSequence(thread uint32, to uint64) {
@@ -213,6 +230,13 @@ func refresh(t testing.TB, sc *StatsClient, dir *adapter.StatDir) {
 	t.Helper()
 	if err := sc.UpdateDir(dir); err != nil {
 		t.Fatalf("UpdateDir: %v", err)
+	}
+}
+
+func refreshErr(t testing.TB, sc *StatsClient, dir *adapter.StatDir) {
+	t.Helper()
+	if err := sc.UpdateDir(dir); err == nil {
+		t.Fatal("UpdateDir succeeded, want rejection")
 	}
 }
 
@@ -404,6 +428,125 @@ func TestRingBufferWindowDerivesMetaStride(t *testing.T) {
 			wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2, 3, 4}, 0, 0)
 			wantWindow(t, s.Windows[1], 16, []uint64{0, 1, 2}, 0, 0)
 		})
+	}
+}
+
+// The stride is derived from where the schema sits, so everything that can make
+// that unreliable has to land on 64 rather than on a guess: VPP's own default
+// for anything but an aarch64 build.
+func TestRingBufferMetaStrideDerivation(t *testing.T) {
+	const metaOff = 64
+	tests := []struct {
+		name       string
+		nThreads   uint32
+		schemaSize uint32
+		metaOff    uint32
+		schemaOff  uint32
+		want       uintptr
+	}{
+		{"64-byte lines", 2, 64, metaOff, metaOff + 2*64, 64},
+		{"128-byte lines", 2, 64, metaOff, metaOff + 2*128, 128},
+		{"four threads at 128", 4, 64, metaOff, metaOff + 4*128, 128},
+		// No schema, so nothing records the array's size. A ring laid out at 128
+		// is read as 64 here: the fallback is wrong on such a build and only the
+		// header carrying the stride outright would fix it.
+		{"no schema falls back", 2, 0, metaOff, metaOff + 2*128, 64},
+		{"schema before metadata", 2, 64, metaOff, metaOff, 64},
+		{"schema inside metadata", 2, 64, metaOff, metaOff - 8, 64},
+		{"array size indivisible by threads", 3, 64, metaOff, metaOff + 200, 64},
+		{"implausible stride", 2, 64, metaOff, metaOff + 2*96, 64},
+		{"metadata past the segment", 2, 64, 1 << 20, 1<<20 + 128, 64},
+		{"no threads", 0, 64, metaOff, metaOff + 128, 64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := make([]byte, 4096)
+			base := dirVector(unsafe.Pointer(&buf[0]))
+			h := (*ringBufferHeader)(unsafe.Pointer(&buf[0]))
+			h.NThreads = tc.nThreads
+			h.SchemaSize = tc.schemaSize
+			h.MetadataOffset = tc.metaOff
+			if int(tc.metaOff)+24 <= len(buf) {
+				(*ringBufferThreadMeta)(unsafe.Pointer(&buf[tc.metaOff])).SchemaOffset = tc.schemaOff
+			}
+
+			got := ringBufferMetaStride(base, h, uint64(len(buf)))
+			if got != tc.want {
+				t.Errorf("stride = %d, want %d", got, tc.want)
+			}
+			runtime.KeepAlive(buf)
+		})
+	}
+}
+
+// A ring whose geometry multiplies out past the address space must be rejected,
+// not have its regions bounded by an end address that wrapped and compared as
+// though it fit. n_threads * ring_size * entry_size is the one product that can:
+// 4 threads of 2^31 entries at 2^31 bytes is exactly 2^64, so an end address
+// formed from it lands back on the ring's own base and looks like it fits, and
+// the refresh goes on to copy from slots the segment never had. Reaching that
+// copy is an out-of-bounds read, so the assertion is as much that nothing
+// panics.
+func TestRingBufferRejectsOverflowingGeometry(t *testing.T) {
+	// Offsets of the ring header's u32 fields.
+	const (
+		offEntrySize = 0
+		offRingSize  = 4
+		offNThreads  = 8
+		offMetaOff   = 20
+		offDataOff   = 24
+	)
+	tests := []struct {
+		name   string
+		fields map[int]uint32
+	}{
+		{"data size wraps to zero", map[int]uint32{
+			offNThreads: 4, offRingSize: 1 << 31, offEntrySize: 1 << 31,
+		}},
+		{"data size wraps on a wider ring", map[int]uint32{
+			offNThreads: 8, offRingSize: 1 << 31, offEntrySize: 1 << 30,
+		}},
+		// Not wrapping, but the same guard: an offset alone past the segment.
+		{"metadata offset past the segment", map[int]uint32{offMetaOff: 0xFFFFFFF0}},
+		{"data offset past the segment", map[int]uint32{offDataOff: 0xFFFFFFF0}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeRing(t, 16, 8, 2)
+			f.produce(0, 4)
+			sc, dir, _ := prepareRing(t, f, 0, false)
+
+			// Corrupted after preparing: PrepareRingBuffer reads the directory
+			// entry only, so the header is first read by the refresh.
+			for off, v := range tc.fields {
+				f.setHeader(off, v)
+			}
+			refreshErr(t, sc, dir)
+		})
+	}
+}
+
+// A ring registered without a schema still has to read, on the stride the
+// fallback assumes.
+func TestRingBufferWindowWithoutSchema(t *testing.T) {
+	f := newFakeRing(t, 16, 8, 2)
+	f.dropSchema()
+	f.produce(0, 2)
+	f.produce(1, 1)
+
+	sc, dir, s := prepareRing(t, f, 0, false)
+	refresh(t, sc, dir)
+	f.produce(0, 3)
+	f.produce(1, 2)
+	refresh(t, sc, dir)
+
+	wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2, 3, 4}, 0, 0)
+	wantWindow(t, s.Windows[1], 16, []uint64{0, 1, 2}, 0, 0)
+	if s.Schema != nil {
+		t.Errorf("Schema = %q, want nil", s.Schema)
+	}
+	if s.Config.SchemaSize != 0 {
+		t.Errorf("Config.SchemaSize = %d, want 0", s.Config.SchemaSize)
 	}
 }
 

--- a/adapter/statsclient/statseg_v2_ring_test.go
+++ b/adapter/statsclient/statseg_v2_ring_test.go
@@ -16,6 +16,7 @@ package statsclient
 
 import (
 	"encoding/binary"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"unsafe"
@@ -40,18 +41,26 @@ const (
 )
 
 type fakeRing struct {
-	buf       []byte
-	ringBase  int // offset of the ring buffer's own header
-	dataOff   int // relative to ringBase
-	metaOff   int // relative to ringBase
-	entrySize uint32
-	ringSize  uint32
-	nThreads  uint32
-	head      []uint32
-	seq       []uint64
+	buf        []byte
+	ringBase   int // offset of the ring buffer's own header
+	dataOff    int // relative to ringBase
+	metaOff    int // relative to ringBase
+	entrySize  uint32
+	ringSize   uint32
+	nThreads   uint32
+	metaStride int
+	head       []uint32
+	seq        []uint64
 }
 
 func newFakeRing(t testing.TB, entrySize, ringSize, nThreads uint32) *fakeRing {
+	t.Helper()
+	return newFakeRingStride(t, entrySize, ringSize, nThreads, ringBufferMetaSize)
+}
+
+// newFakeRingStride lays the metadata array out with the given stride, which on
+// a real segment is VPP's CLIB_CACHE_LINE_BYTES.
+func newFakeRingStride(t testing.TB, entrySize, ringSize, nThreads uint32, metaStride int) *fakeRing {
 	t.Helper()
 
 	const (
@@ -68,20 +77,21 @@ func newFakeRing(t testing.TB, entrySize, ringSize, nThreads uint32) *fakeRing {
 
 	// Offsets below are relative to ringBase, which is what the header declares.
 	metaOff := 64 // past the ring header, cache-line aligned as VPP has it
-	schemaOff := metaOff + int(nThreads)*ringBufferMetaSize
+	schemaOff := metaOff + int(nThreads)*metaStride
 	dataOff := align8(schemaOff + len(fakeRingSchema) + 1)
 	total := ringBase + dataOff + int(nThreads)*int(ringSize)*int(entrySize) + trailer
 
 	f := &fakeRing{
-		buf:       make([]byte, total),
-		ringBase:  ringBase,
-		dataOff:   dataOff,
-		metaOff:   metaOff,
-		entrySize: entrySize,
-		ringSize:  ringSize,
-		nThreads:  nThreads,
-		head:      make([]uint32, nThreads),
-		seq:       make([]uint64, nThreads),
+		buf:        make([]byte, total),
+		ringBase:   ringBase,
+		dataOff:    dataOff,
+		metaOff:    metaOff,
+		entrySize:  entrySize,
+		ringSize:   ringSize,
+		nThreads:   nThreads,
+		metaStride: metaStride,
+		head:       make([]uint32, nThreads),
+		seq:        make([]uint64, nThreads),
 	}
 
 	f.putU64(fakeOffVersion, 2)
@@ -107,7 +117,7 @@ func newFakeRing(t testing.TB, entrySize, ringSize, nThreads uint32) *fakeRing {
 	copy(f.buf[ringBase+schemaOff:], fakeRingSchema)
 
 	for i := uint32(0); i < nThreads; i++ {
-		m := ringBase + metaOff + int(i)*ringBufferMetaSize
+		m := ringBase + metaOff + int(i)*metaStride
 		f.putU32(m+0, 0)                  // head
 		f.putU32(m+4, 1)                  // schema version
 		f.putU64(m+8, 0)                  // sequence
@@ -130,8 +140,10 @@ func (f *fakeRing) putDirEntry(dirOff, index int, typ dirType, union uint64, nam
 	e.name[len(name)] = 0
 }
 
-// produce writes n entries as a VPP worker would: entry body first, then the
-// head and sequence that publish it.
+// produce writes n entries as vlib_stats_ring_produce does: entry body first,
+// then head, then the sequence that publishes it. Head and sequence are tracked
+// separately here, as VPP tracks them, so a slot derived from the wrong one is
+// still a visible difference.
 func (f *fakeRing) produce(thread uint32, n int) {
 	for i := 0; i < n; i++ {
 		slot := f.head[thread]
@@ -142,25 +154,25 @@ func (f *fakeRing) produce(thread uint32, n int) {
 		f.head[thread] = (slot + 1) % f.ringSize
 		f.seq[thread]++
 	}
-	m := f.ringBase + f.metaOff + int(thread)*ringBufferMetaSize
+	m := f.ringBase + f.metaOff + int(thread)*f.metaStride
 	f.putU32(m+0, f.head[thread])
 	f.putU64(m+8, f.seq[thread])
 }
 
-// rewindSequence makes the producer's count go backwards, as a VPP restart on
-// the same segment would.
 // publishHeadAhead advances the published head by one without publishing the
 // sequence that explains it. That is the state a producer is in between its
 // plain store of head and its release store of the sequence, and it is what a
 // consumer sees when it reads the two astride a commit.
 func (f *fakeRing) publishHeadAhead(thread uint32) {
-	m := f.ringBase + f.metaOff + int(thread)*ringBufferMetaSize
+	m := f.ringBase + f.metaOff + int(thread)*f.metaStride
 	f.putU32(m+0, (f.head[thread]+1)%f.ringSize)
 }
 
+// rewindSequence makes the producer's count go backwards, as a VPP restart on
+// the same segment would.
 func (f *fakeRing) rewindSequence(thread uint32, to uint64) {
 	f.seq[thread] = to
-	f.putU64(f.ringBase+f.metaOff+int(thread)*ringBufferMetaSize+8, to)
+	f.putU64(f.ringBase+f.metaOff+int(thread)*f.metaStride+8, to)
 }
 
 func (f *fakeRing) client() *StatsClient {
@@ -363,6 +375,35 @@ func TestRingBufferWindowResyncsOnSequenceRewind(t *testing.T) {
 	}
 	if s.Windows[0].NextSeq != 2 {
 		t.Errorf("NextSeq = %d, want 2: the reader must re-sync to what is there now", s.Windows[0].NextSeq)
+	}
+}
+
+// VPP pads its metadata array to CLIB_CACHE_LINE_BYTES, 128 on aarch64 builds,
+// and the ring header does not say which. Thread 0 sits at the start of the
+// array either way, so only threads after it can catch a wrong stride: at 128
+// with a hard-coded 64, thread 1's metadata is read out of thread 0's padding
+// and the thread looks idle.
+func TestRingBufferWindowDerivesMetaStride(t *testing.T) {
+	for _, stride := range []int{ringBufferMetaSize, ringBufferMetaSizeAlt} {
+		t.Run(fmt.Sprint(stride), func(t *testing.T) {
+			f := newFakeRingStride(t, 16, 8, 2, stride)
+			f.produce(0, 3)
+			f.produce(1, 2)
+
+			sc, dir, s := prepareRing(t, f, 0, false)
+			refresh(t, sc, dir)
+
+			if got := s.Threads[1].Sequence; got != 2 {
+				t.Fatalf("thread 1 sequence = %d, want 2", got)
+			}
+
+			f.produce(0, 2)
+			f.produce(1, 1)
+			refresh(t, sc, dir)
+
+			wantWindow(t, s.Windows[0], 16, []uint64{0, 1, 2, 3, 4}, 0, 0)
+			wantWindow(t, s.Windows[1], 16, []uint64{0, 1, 2}, 0, 0)
+		})
 	}
 }
 


### PR DESCRIPTION
A ring-buffer stat could only be read whole. `CopyEntryData` copies every
thread's entire ring into a fresh allocation, so a read costs the size of the
ring rather than the number of entries produced into it - which is the wrong way
round, because a ring is sized for burst headroom. An 8192-entry ring of
128-byte records is 1 MiB per thread per read, so a ring big enough to survive a
stall is too expensive to poll.

`adapter.RingBufferWindowStat` copies only what the producers appended since the
previous refresh, into buffers it already owns. On an 8192-entry ring delivering
256 entries, 483 us / 1 MiB / 5 allocations becomes 4.1 us and none.

The read cursor is consumer-side state - a field on the stat the caller holds,
not anything in the segment, which is mapped read-only - so a window refreshes
through `UpdateDir` like any other prepared entry. `PrepareRingBuffer` is
separate because `PrepareDir` populates entries with `CopyEntryData`, which
would copy the whole ring at prepare time and again on every epoch change. It
hangs off `adapter.RingBufferAPI` because a mock or a v1 segment has nowhere to
carry a cursor.

Entries are located from the sequence and not from head: a producer stores head
plainly and then publishes the sequence with a release store, so a pair read
astride a commit shows a head one slot ahead, and positioning off head delivers
the slot a worker is writing. A copy is also validated against the producer
afterwards, because the optimistic lock covers directory changes rather than ring
data - entries overwritten mid-copy are the oldest of the window, so dropping
them from the front leaves the ones still whole, counted as `Lost`. `Lost` and
`Pending` stay apart because they call for opposite responses.

Review also turned up two things in the code this touches. The per-thread
metadata stride was hard-coded to 64, but VPP pads
`vlib_stats_ring_metadata_t` to `CLIB_CACHE_LINE_BYTES` and
`src/cmake/cpu.cmake` sets that to 128 on aarch64 unless a platform file says
otherwise - five of its six aarch64 platforms do, octeon9 does not. On such a
build thread 1 and up were read out of thread 0's padding. That mattered more
here than on master, where a wrong address only corrupted the reported `Head`
and `Sequence`; a window picks its slots from those.

The stride is not stated anywhere, but a schema-bearing ring implies it: VPP
puts the schema directly after the metadata array and records that offset in
every thread's metadata, thread 0's included, which sits at the start of the
array whatever the stride is. So the array's size follows from thread 0 alone.
Without a schema there is nothing to derive it from and 64 is assumed, which is
wrong on those builds; #390 covers publishing the size in the shared header
instead. `copyRingBufferData` reads the stride too, so `RingBufferStat` is no
longer wrong on aarch64 either.

The other is bounds-checking: each region is now sized against the room left in
the segment rather than by forming its end address. Four threads of 2^31
entries at 2^31 bytes multiplies to exactly 2^64, so an end address formed from
it wrapped onto the ring's own base and compared as though it fit.

Tested against a synthetic v2 segment covering first-refresh positioning, the
seam, loss on a lap, the cap and drain loop, sequence rewind, a head published
ahead of its sequence, overwrite during a copy, and a zero-allocation steady
refresh. The stride is covered at 64 and 128 and at every input that must fall
back rather than guess; the fake ring takes a stride rather than the constant,
so these cases can fail. Each was checked against the code it guards - the
first overflow case passed against the unfixed bounds check until the geometry
above replaced it. `go vet`'s unsafe.Pointer warnings for this file drop from
three to none.
