### PR TITLE
adapter/statsclient: bounds-check a symlink's target index

### DIFF
--- a/adapter/statsclient/statsclient.go
+++ b/adapter/statsclient/statsclient.go
@@ -699,12 +699,23 @@ func (sc *StatsClient) updateSymlinkGroups(vector dirVector, groups map[uint32][
 	}
 	dirLen := *(*uint32)(vectorLen(vector))
 	for target, refs := range groups {
+		// Deliberately no fallback to resolving each symlink on its own here,
+		// unlike the shape mismatch below: CopyEntryData derives the target's
+		// directory segment from this same index, so handing it one already
+		// known to be out of range would turn a skipped group into an
+		// out-of-bounds read of the mapped segment. The group keeps its
+		// previous value, which no caller observes: a directory that has been
+		// re-laid-out fails accessEnd and the whole refresh is rejected.
 		if target >= dirLen {
 			debugf("symlink target index %d out of dir vector length (%d)", target, dirLen)
 			continue
 		}
 		targetPtr, targetName, _ := sc.GetStatDirOnIndex(vector, target)
 		if len(targetName) == 0 {
+			// A freed directory slot - VPP zeroes the name when it removes an
+			// entry. Resolving through it would read whatever the slot still
+			// points at, so skip it for the same reason as above.
+			debugf("symlink target index %d has no name", target)
 			continue
 		}
 		full := sc.CopyEntryData(targetPtr, ^uint32(0))

--- a/adapter/statsclient/statseg_v2.go
+++ b/adapter/statsclient/statseg_v2.go
@@ -264,6 +264,21 @@ func (ss *statSegmentV2) CopyEntryData(segment dirSegment, index uint32) adapter
 		// use first index to get the stats directory the symlink points to
 		header := ss.loadSharedHeader(ss.sharedHeader)
 		dirVector := ss.adjust(dirVector(&header.dirVector))
+		if dirVector == nil {
+			debugf("directory vector pointer is out of range for %s", dirEntry.name)
+			return nil
+		}
+		// The target index is read from the segment, so it is only as
+		// trustworthy as the process writing it. A directory entry is 144
+		// bytes, so an out-of-range uint32 addresses hundreds of gigabytes
+		// past the mapping and the recursive call faults on its first read
+		// rather than returning anything. This is the only guard on the
+		// DumpStats and PrepareDir paths; UpdateDir has updateSymlinkGroups.
+		if dirLen := *(*uint32)(vectorLen(dirVector)); i1 >= dirLen {
+			debugf("symlink target index %d out of dir vector length (%d) for %s",
+				i1, dirLen, dirEntry.name)
+			return nil
+		}
 		statSegDir2 := dirSegment(uintptr(dirVector) + uintptr(i1)*unsafe.Sizeof(statSegDirectoryEntryV2{}))
 
 		// retry with actual stats segment and use second index to get

--- a/adapter/statsclient/statseg_v2_fake_test.go
+++ b/adapter/statsclient/statseg_v2_fake_test.go
@@ -62,6 +62,16 @@ type fakeSegment struct {
 	buf []byte
 	// counters is the offset of the backing counter data for thread 0.
 	counters int
+	// dirOff is the offset of the directory vector's data, and nDir its declared
+	// length, so a test can reach in and corrupt an entry.
+	dirOff int
+	nDir   int
+	// spareDir is a directory slot present in the buffer but beyond the vector's
+	// declared length, holding a perfectly valid counter-vector entry. A symlink
+	// pointed at it resolves cleanly if the declared length is not honoured, and
+	// is rejected if it is - which is what makes the bounds check testable
+	// without depending on an out-of-range read happening to fault.
+	spareDir int
 }
 
 // newFakeSegment builds a segment holding a /node/errors vector with the given
@@ -84,13 +94,15 @@ func newFakeSegment(t testing.TB, values []uint64) *fakeSegment {
 
 	dirLenOff := hdrSize
 	dirOff := dirLenOff + vecHdr
-	ptLenOff := dirOff + nDir*dirEntLen // per-thread vector of pointers
+	// One slot past the declared length, see fakeSegment.spareDir.
+	ptLenOff := dirOff + (nDir+1)*dirEntLen // per-thread vector of pointers
 	ptOff := ptLenOff + vecHdr
 	ctLenOff := ptOff + threads*ptrSize // thread 0 counter vector
 	ctOff := ctLenOff + vecHdr
 	total := ctOff + len(values)*ptrSize + trailer
 
-	f := &fakeSegment{buf: make([]byte, total), counters: ctOff}
+	f := &fakeSegment{buf: make([]byte, total), counters: ctOff,
+		dirOff: dirOff, nDir: nDir, spareDir: nDir}
 
 	// Shared header. errorVector stays zero: adjust() then rejects it, which is how
 	// the client decides a segment uses the modern (non-legacy) type mapping.
@@ -124,6 +136,10 @@ func newFakeSegment(t testing.TB, values []uint64) *fakeSegment {
 		union := uint64(fakeTargetIndex) | uint64(item)<<32
 		f.putDirEntry(dirOff, fakeTargetIndex+1+i, fakeTypeSymlink, union, fakeErrName(item))
 	}
+
+	// The spare slot: a valid entry the declared vector length excludes.
+	f.putDirEntry(dirOff, f.spareDir, fakeTypeSimpleCounterVector,
+		fakeBase+uint64(ptOff), "/sys/fake-beyond-vector")
 	return f
 }
 
@@ -146,6 +162,13 @@ func fakeErrItem(t testing.TB, name []byte) uint32 {
 
 func (f *fakeSegment) putU64(off int, v uint64) {
 	*(*uint64)(unsafe.Pointer(&f.buf[off])) = v
+}
+
+// dirEntry returns the directory entry at index, so a test can corrupt one the
+// way a misbehaving producer would.
+func (f *fakeSegment) dirEntry(index int) *statSegDirectoryEntryV2 {
+	return (*statSegDirectoryEntryV2)(unsafe.Pointer(
+		&f.buf[f.dirOff+index*int(unsafe.Sizeof(statSegDirectoryEntryV2{}))]))
 }
 
 func (f *fakeSegment) putDirEntry(dirOff, index int, typ dirType, union uint64, name string) {

--- a/adapter/statsclient/statseg_v2_symlink_bounds_test.go
+++ b/adapter/statsclient/statseg_v2_symlink_bounds_test.go
@@ -1,0 +1,166 @@
+//  Copyright (c) 2026 Meter, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package statsclient
+
+import (
+	"testing"
+)
+
+// A symlink's target index is read straight out of the segment, so it is only as
+// trustworthy as the process writing it. Resolving one addresses the directory
+// vector at 144 bytes an entry, so a large out-of-range index lands far outside
+// the mapping and faults.
+//
+// A test cannot assert on a fault, and an index chosen to be wildly out of range
+// proves nothing either: it lands in unrelated mapped memory, reads garbage as
+// the directory type and falls out of the type switch as nil, which is what the
+// fix produces anyway. So these point a symlink at fakeSegment.spareDir - a valid
+// entry that the vector's declared length excludes. Resolving it succeeds if the
+// length is not honoured and is refused if it is, which is exactly the
+// distinction under test.
+
+// corruptSymlinkTarget repoints the symlink naming item at a directory index the
+// vector does not have, leaving every other entry alone.
+func corruptSymlinkTarget(t *testing.T, f *fakeSegment, item uint32, target uint32) {
+	t.Helper()
+	want := fakeErrName(item)
+	for i := 0; i < f.nDir; i++ {
+		e := f.dirEntry(i)
+		n := 0
+		for ; n < len(e.name) && e.name[n] != 0; n++ {
+		}
+		if string(e.name[:n]) != want {
+			continue
+		}
+		e.unionData = uint64(target) | uint64(item)<<32
+		return
+	}
+	t.Fatalf("no symlink entry named %s", want)
+}
+
+func TestCopyEntryDataRejectsOutOfRangeSymlinkTarget(t *testing.T) {
+	values := []uint64{10, 20, 30, 40}
+	f := newFakeSegment(t, values)
+	corruptSymlinkTarget(t, f, 2, uint32(f.spareDir))
+
+	entries, err := f.client().DumpStats()
+	if err != nil {
+		t.Fatal("DumpStats failed:", err)
+	}
+
+	var checked int
+	for _, e := range entries {
+		if !e.Symlink {
+			continue
+		}
+		item := fakeErrItem(t, e.Name)
+		checked++
+		if item == 2 {
+			// Unresolvable, so it must carry no data rather than something
+			// read from outside the segment.
+			if e.Data != nil {
+				t.Errorf("%s: target is out of range, want nil Data, got %v", e.Name, e.Data)
+			}
+			continue
+		}
+		// One bad entry must not disturb its neighbours.
+		if got, want := symlinkValue(t, e), values[item]; got != want {
+			t.Errorf("%s: value = %d, want %d", e.Name, got, want)
+		}
+	}
+	if checked != len(values) {
+		t.Fatalf("checked %d symlink entries, want %d", checked, len(values))
+	}
+}
+
+// The grouped refresh path has its own guard, in updateSymlinkGroups. It skips the
+// group rather than falling back to resolving each symlink on its own, because that
+// fallback would hand CopyEntryData the very index just found to be out of range.
+func TestUpdateDirSkipsOutOfRangeSymlinkTarget(t *testing.T) {
+	values := []uint64{10, 20, 30, 40}
+	f := newFakeSegment(t, values)
+	sc := f.client()
+
+	dir, err := sc.PrepareDir("/err/")
+	if err != nil {
+		t.Fatal("PrepareDir failed:", err)
+	}
+	if len(dir.Entries) != len(values) {
+		t.Fatalf("prepared %d entries, want %d", len(dir.Entries), len(values))
+	}
+
+	// Corrupt after preparing, so the entries hold a resolved value that the
+	// refresh must then leave alone rather than replace with the spare slot's.
+	corruptSymlinkTarget(t, f, 2, uint32(f.spareDir))
+	for i := range values {
+		f.setCounter(i, values[i]*100)
+	}
+
+	if err := sc.UpdateDir(dir); err != nil {
+		t.Fatal("UpdateDir failed:", err)
+	}
+
+	for i := range dir.Entries {
+		e := &dir.Entries[i]
+		item := fakeErrItem(t, e.Name)
+		got := symlinkValue(t, *e)
+		if item == 2 {
+			// The whole group is skipped, so this keeps its PrepareDir value.
+			if got != values[item] {
+				t.Errorf("%s: value = %d, want the unrefreshed %d", e.Name, got, values[item])
+			}
+			continue
+		}
+		if want := values[item] * 100; got != want {
+			t.Errorf("%s: value = %d, want the refreshed %d", e.Name, got, want)
+		}
+	}
+}
+
+// A symlink whose target names a freed directory slot - VPP zeroes an entry's name
+// when it removes it - is skipped for the same reason, and must not resolve to
+// whatever the slot still points at.
+func TestUpdateDirSkipsSymlinkToFreedSlot(t *testing.T) {
+	values := []uint64{10, 20, 30, 40}
+	f := newFakeSegment(t, values)
+	sc := f.client()
+
+	dir, err := sc.PrepareDir("/err/")
+	if err != nil {
+		t.Fatal("PrepareDir failed:", err)
+	}
+
+	// Free the backing vector's slot the way VPP does, keeping its data pointer.
+	target := f.dirEntry(fakeTargetIndex)
+	for i := range target.name {
+		target.name[i] = 0
+	}
+	for i := range values {
+		f.setCounter(i, values[i]*100)
+	}
+
+	if err := sc.UpdateDir(dir); err != nil {
+		t.Fatal("UpdateDir failed:", err)
+	}
+
+	// Every group aliased that one entry, so none of them refresh.
+	for i := range dir.Entries {
+		e := &dir.Entries[i]
+		item := fakeErrItem(t, e.Name)
+		if got := symlinkValue(t, *e); got != values[item] {
+			t.Errorf("%s: value = %d, want the unrefreshed %d", e.Name, got, values[item])
+		}
+	}
+}


### PR DESCRIPTION
Fixes #388.

`CopyEntryData` derives a symlink's target directory segment from the index the
entry carries and dereferences it without checking either the index or the
vector. A directory entry is 144 bytes, so an out-of-range `uint32` addresses
hundreds of gigabytes past the mapping: the recursive call reads
`directoryType` at an address that is almost always unmapped, and faults. Where
it is mapped it returns unrelated process memory as a counter. `adjust()`
returning nil was unchecked here too, alone among the call sites in that
function.

The index comes out of shared memory another process writes, so it is only as
trustworthy as that process. Nothing in govpp can produce a bad one - it takes
VPP publishing an index that is structurally valid but wrong, or a directory
read astride a re-layout, and the optimistic lock does not help with the
second, because `accessEnd` validates the epoch only after the reads, which is
too late to prevent a fault.

`UpdateDir` was already covered: `updateSymlinkGroups` rejects
`target >= dirLen` before resolving a group. `DumpStats` and `PrepareDir` reach
the symlink case through `CopyEntryData` directly and were not.

That guard reads as an inconsistency next to the shape mismatch below it, which
does fall back to resolving each symlink on its own, so it now says why it
cannot: the fallback would hand `CopyEntryData` the very index just found to be
out of range. The sibling skip for a target whose name is empty - a freed
directory slot, since VPP zeroes an entry's name when it removes it - gets the
same note and the `debugf` it was missing.

The test points a symlink at a directory slot the synthetic v2 segment holds but
its declared vector length excludes, so resolving it succeeds without the check
and is refused with it; reverting the check fails the test with the counter
value it read past the end. An index chosen to be wildly out of range would
prove nothing - it lands in unrelated mapped memory, reads garbage as the
directory type and falls out of the type switch as nil, which is what the fix
produces anyway.
