### PR TITLE
adapter/statsclient: hold accessLock during Disconnect to avoid segfault

### DIFF
--- a/adapter/statsclient/statsclient.go
+++ b/adapter/statsclient/statsclient.go
@@ -156,6 +156,14 @@ func (sc *StatsClient) Disconnect() error {
 		close(sc.done)
 	}
 
+	// Without this lock, disconnect()'s munmap races any reader holding only
+	// accessLock.RLock() (DumpStats, ListStats, PrepareDir, UpdateDir): the
+	// isConnected atomic is checked, munmap runs concurrently with a read still
+	// in progress, and the read segfaults on the now-unmapped region.
+	// reconnect() already takes this lock around the same disconnect() call.
+	sc.accessLock.Lock()
+	defer sc.accessLock.Unlock()
+
 	if !sc.isConnected() {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- `Disconnect()` unmapped the shared memory segment without taking `accessLock`, unlike `reconnect()` which correctly wraps `disconnect()`+`connect()` in `accessLock.Lock()`.
- `DumpStats`, `ListStats`, `PrepareDir` and `UpdateDir` only take `accessLock.RLock()`, so a concurrent `Disconnect()` could `munmap` the segment while one of those was mid-read, faulting inside `loadSharedHeader` on the now-unmapped region.
- This is reachable in practice: `core.StatsConnection` runs a health-check goroutine that calls `ListStats` on its own ticker, independent of whatever locking a caller wraps around `Disconnect()`.
- Fix: take `accessLock.Lock()` in `Disconnect()` before checking connection state and unmapping, mirroring `reconnect()`.

## Test plan
- [x] `go build ./adapter/... ./core/...`
- [x] `go vet ./adapter/statsclient/...`
- [x] `go test -race ./adapter/statsclient/...`